### PR TITLE
Standardize vector API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@ Tested in MSVC and GCC (Ubuntu)
 
 ## Data types
 ### Vector
-- vec5f, vec5i
+- vec5f, vec5i, vec5u
 - vec4f, vec4i, vec4u
-- vec3f, vec3u
+- vec3f, vec3i, vec3u
 - vec2f, vec2i, vec2u
+
+### 8-bit RGB and RGBA
+- vec3u8
+- vec4u8
 
 ### Matrix
 - mat5
@@ -19,6 +23,7 @@ Tested in MSVC and GCC (Ubuntu)
 - aabb4f
 - aabb4i
 - aabb3f
+- aabb3i
 
 ### Rotors
 - rotor4
@@ -41,7 +46,7 @@ etc.
 ```
 
 ### TODO:
-- Standardize vec, mat, and aabb APIs
+- Standardize ~~vec~~, mat, and aabb APIs
 - ~~Add some Rotor rotation code~~
 - ~~Unit tests and/or sample project~~
 - ~~ONB (Orthonormal Basis)~~

--- a/README.md
+++ b/README.md
@@ -20,10 +20,8 @@ Tested in MSVC and GCC (Ubuntu)
 - mat3
 
 ### Axis-Aligned Bounding Box
-- aabb4f
-- aabb4i
-- aabb3f
-- aabb3i
+- aabb4f, aabb4i
+- aabb3f, aabb3i
 
 ### Rotors
 - rotor4
@@ -47,10 +45,13 @@ etc.
 
 ### TODO:
 - Standardize ~~vec~~, mat, and aabb APIs
+- Move helper functions to utils files for vec, mat, aabb, etc.
 - ~~Add some Rotor rotation code~~
 - ~~Unit tests and/or sample project~~
 - ~~ONB (Orthonormal Basis)~~
 - Spherical-to-Cartesian and Cartesian-to-Spherical conversion
 - Header-only
 - Version number
-- Double-precision
+- Double-precision (64-bit)
+- Half precision (16-bit)
+- rotor3

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,6 +9,7 @@ set (HEADERS
 	${INCLUDE_DIR}/vec.h
 	${INCLUDE_DIR}/rotor.h
 	${INCLUDE_DIR}/onb.h
+	${INCLUDE_DIR}/vecUtils.h
 	)
 
 set (MATH_SOURCES

--- a/examples/main.h
+++ b/examples/main.h
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include "vec.h"
+#include "vecUtils.h"
 #include "aabb.h"
 #include "mat.h"
 #include "hxMath.h"

--- a/examples/main.h
+++ b/examples/main.h
@@ -189,6 +189,59 @@ bool testVector()
 		success = false;
 	}
 
+	// negation operators
+	{
+		const vec2f vPos2f = { 1, 2 };
+		const vec2i vPos2i = { 1, 2 };
+		const vec3f vPos3f = { 1, 2, 3 };
+		const vec3i vPos3i = { 1, 2, 3 };
+		const vec4f vPos4f = { 1, 2, 3, 4 };
+		const vec4i vPos4i = { 1, 2, 3, 4 };
+		const vec5f vPos5f = { 1, 2, 3, 4, 5 };
+		const vec5i vPos5i = { 1, 2, 3, 4, 5 };
+
+		if (-vPos2f != vec2f(-1, -2))
+		{
+			std::printf("vec2f negation failed!\n");
+			success = false;
+		}
+		if (-vPos2i != vec2i(-1, -2))
+		{
+			std::printf("vec2i negation failed!\n");
+			success = false;
+		}
+		if (-vPos3f != vec3f(-1, -2, -3))
+		{
+			std::printf("vec3f negation failed!\n");
+			success = false;
+		}
+		if (-vPos3i != vec3i(-1, -2, -3))
+		{
+			std::printf("vec3i negation failed!\n");
+			success = false;
+		}
+		if (-vPos4f != vec4f(-1, -2, -3, -4))
+		{
+			std::printf("vec4f negation failed!\n");
+			success = false;
+		}
+		if (-vPos4i != vec4i(-1, -2, -3, -4))
+		{
+			std::printf("vec4i negation failed!\n");
+			success = false;
+		}
+		if (-vPos5f != vec5f(-1, -2, -3, -4, -5))
+		{
+			std::printf("vec4f negation failed!\n");
+			success = false;
+		}
+		if (-vPos5i != vec5i(-1, -2, -3, -4, -5))
+		{
+			std::printf("vec5i negation failed!\n");
+			success = false;
+		}
+	}
+
 	return success;
 }
 

--- a/src/aabb.cpp
+++ b/src/aabb.cpp
@@ -10,7 +10,168 @@ Justin Jensen
 
 namespace hxm
 {
-    // AABB3 (float) ------------------------------------------------------------
+    // AABB3I -------------------------------------------------------------------
+    void aabb3i::addPoint(const vec3i& pt, bool halfOpenInterval)
+    {
+        _b[0].x = std::min(pt.x, _b[0].x);
+        _b[0].y = std::min(pt.y, _b[0].y);
+        _b[0].z = std::min(pt.z, _b[0].z);
+
+        if (halfOpenInterval)
+        {
+            _b[1].x = std::max(pt.x + 1, _b[1].x);
+            _b[1].y = std::max(pt.y + 1, _b[1].y);
+            _b[1].z = std::max(pt.z + 1, _b[1].z);
+        }
+        else
+        {
+            _b[1].x = std::max(pt.x, _b[1].x);
+            _b[1].y = std::max(pt.y, _b[1].y);
+            _b[1].z = std::max(pt.z, _b[1].z);
+        }
+    }
+
+    vec3i aabb3i::dim() const
+    {
+        return max() - min();
+    }
+
+    bool aabb3i::empty() const
+    {
+        vec3i theDim = dim();
+        return (theDim.x <= 0 || theDim.y <= 0 || theDim.z <= 0);
+    }
+
+    bool aabb3i::isValid(bool halfOpenInterval) const
+    {
+        if (halfOpenInterval)
+        {
+            return !(max().x <= min().x || max().y <= min().y || max().z <= min().z);
+        }
+        else
+        {
+            return !(max().x < min().x || max().y < min().y || max().z < min().z);
+        }
+    }
+
+    void aabb3i::addAABB(const aabb3i& other)
+    {
+        _b[0].x = std::min(other.min().x, _b[0].x);
+        _b[0].y = std::min(other.min().y, _b[0].y);
+        _b[0].z = std::min(other.min().z, _b[0].z);
+
+        _b[1].x = std::max(other.max().x, _b[1].x);
+        _b[1].y = std::max(other.max().y, _b[1].y);
+        _b[1].z = std::max(other.max().z, _b[1].z);
+    }
+
+    aabb3i aabb3i::intersect(const aabb3i& other) const
+    {
+        aabb3i result;
+        result._b[0].x = std::max(_b[0].x, other.min().x);
+        result._b[0].y = std::max(_b[0].y, other.min().y);
+        result._b[0].z = std::max(_b[0].z, other.min().z);
+
+        result._b[1].x = std::min(_b[1].x, other.max().x);
+        result._b[1].y = std::min(_b[1].y, other.max().y);
+        result._b[1].z = std::min(_b[1].z, other.max().z);
+
+        return result;
+    }
+
+    aabb3i aabb3i::intersect(const vec3i& otherStart, const vec3i& otherEnd) const
+    {
+        aabb3i result;
+        for (uint32_t cIdx = 0; cIdx < 3; cIdx++)
+        {
+            result._b[0][cIdx] = std::max(otherStart[cIdx], _b[0][cIdx]);
+            result._b[1][cIdx] = std::min(otherEnd[cIdx], _b[1][cIdx]);
+        }
+
+        return result;
+    }
+
+    int aabb3i::area(bool halfOpenInterval) const
+    {
+        vec3i d = dim();
+        if (!halfOpenInterval)
+            d += 1;
+
+        return 2 * ((d.x * d.y) + (d.x * d.z) + (d.y * d.z));
+    }
+
+    int aabb3i::volume(bool halfOpenInterval) const
+    {
+        if (!isValid())
+        {
+            return 0;
+        }
+
+        vec3i tDim;
+        if (halfOpenInterval)
+        {
+            tDim = max() - min();
+        }
+        else
+        {
+            tDim = (max() + 1) - min();
+        }
+
+        return tDim.x * tDim.y * tDim.z;
+    }
+
+    void aabb3i::reset()
+    {
+        _b[0] = vec3i(INT_MAX);
+        _b[1] = vec3i(INT_MIN);
+    }
+
+    vec3i& aabb3i::operator[](uint32_t idx)
+    {
+        return _b[idx];
+    }
+
+    vec3i aabb3i::operator[](uint32_t idx) const
+    {
+        return _b[idx];
+    }
+
+    vec3i aabb3i::min() const
+    {
+        return _b[0];
+    }
+
+    vec3i aabb3i::max() const
+    {
+        return _b[1];
+    }
+
+    aabb3i& aabb3i::operator+=(const aabb3i& other)
+    {
+        _b[0].x = std::min(other.min().x, _b[0].x);
+        _b[0].y = std::min(other.min().y, _b[0].y);
+        _b[0].z = std::min(other.min().z, _b[0].z);
+
+        _b[1].x = std::max(other.max().x, _b[1].x);
+        _b[1].y = std::max(other.max().y, _b[1].y);
+        _b[1].z = std::max(other.max().z, _b[1].z);
+
+        return *this;
+    }
+
+    aabb3i::aabb3i()
+    {
+        reset();
+    }
+
+    aabb3i::aabb3i(const vec3i& min, const vec3i& max)
+    {
+        _b[0] = min;
+        _b[1] = max;
+    }
+    // END AABB3I ---------------------------------------------------------------
+
+    // AABB3F ------------------------------------------------------------
     void aabb3f::addPoint(const vec3f& pt)
     {
         _b[0].x = std::min(pt.x, _b[0].x);

--- a/src/aabb.h
+++ b/src/aabb.h
@@ -15,11 +15,64 @@ namespace hxm
 {
     // Forward declarations of classes here
     class aabb3f;
+    class aabb3i;
     class aabb4f;
     class aabb4i;
 
     typedef aabb3f aabb3;
     typedef aabb4f aabb4;
+
+    // AABB3I -------------------------------------------------------------------
+    class aabb3i
+    {
+        // Defines
+    private:
+    protected:
+    public:
+
+        // Members
+    private:
+    protected:
+    public:
+        union
+        {
+            int32_t _v[6];              // { min_x, min_y, min_z, max_x, max_y, max_z }
+            struct { vec3i _b[2]; };    // { min, max }
+        };
+
+        // Functions
+    private:
+    protected:
+    public:
+        // halfOpenInterval means the AABB includes _min and includes _max-1, but does not include _max
+        void addPoint(const vec3i& pt, bool halfOpenInterval = false);
+
+        vec3i dim() const;
+
+        bool empty() const;
+        bool isValid(bool halfOpenInterval = true) const;
+
+        void addAABB(const aabb3i& other);
+
+        aabb3i intersect(const aabb3i& other) const;
+        aabb3i intersect(const vec3i& otherStart, const vec3i& otherEnd) const;
+
+        int area(bool halfOpenInterval = true) const; // surface area
+        int volume(bool halfOpenInterval = true) const;
+
+        void reset();
+
+        vec3i& operator[](uint32_t idx);        // 0: min, 1: max
+        vec3i operator[](uint32_t idx) const;
+        vec3i min() const;
+        vec3i max() const;
+        aabb3i& operator+=(const aabb3i& other);
+
+        aabb3i();
+        aabb3i(const vec3i& min, const vec3i& max);
+        ~aabb3i() {}
+    };
+    // END AABB3I ---------------------------------------------------------------
 
     // AABB3F -------------------------------------------------------------------
     class aabb3f
@@ -127,7 +180,7 @@ namespace hxm
         aabb4i(const vec4i& min, const vec4i& max);
         ~aabb4i() {}
     };
-    // END AABBI ---------------------------------------------------------------
+    // END AABB4I ---------------------------------------------------------------
 
 
     // AABB4F -------------------------------------------------------------------

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -18,10 +18,24 @@ namespace hxm
         return *this;
     }
 
+    vec2f& vec2f::operator+=(const float rhs)
+    {
+        x += rhs;
+        y += rhs;
+        return *this;
+    }
+
     vec2f& vec2f::operator-=(const vec2f& rhs)
     {
         x -= rhs.x;
         y -= rhs.y;
+        return *this;
+    }
+
+    vec2f& vec2f::operator-=(const float rhs)
+    {
+        x -= rhs;
+        y -= rhs;
         return *this;
     }
 
@@ -32,7 +46,7 @@ namespace hxm
         return *this;
     }
 
-    vec2f& vec2f::operator*=(float rhs)
+    vec2f& vec2f::operator*=(const float rhs)
     {
         x *= rhs;
         y *= rhs;
@@ -46,7 +60,7 @@ namespace hxm
         return *this;
     }
 
-    vec2f& vec2f::operator/=(float rhs)
+    vec2f& vec2f::operator/=(const float rhs)
     {
         x /= rhs;
         y /= rhs;
@@ -93,12 +107,14 @@ namespace hxm
 
     float vec2f::length() const
     {
-        return sqrt(this->dot(*this));
+        return std::sqrt((x * x) + (y * y));
     }
 
-    vec2f& vec2f::normalize()
+    float vec2f::normalize()
     {
-        return (*this) /= (length());
+        const float len = length();
+        (*this) /= len;
+        return len;
     }
 
     vec2f::vec2f() : x(0), y(0) {}
@@ -117,6 +133,13 @@ namespace hxm
         return *this;
     }
 
+    vec2i& vec2i::operator+=(const int32_t rhs)
+    {
+        x += rhs;
+        y += rhs;
+        return *this;
+    }
+
     vec2i& vec2i::operator-=(const vec2i& rhs)
     {
         x -= rhs.x;
@@ -124,9 +147,44 @@ namespace hxm
         return *this;
     }
 
-    bool vec2i::operator==(const vec2i& other) const
+    vec2i& vec2i::operator-=(const int32_t rhs)
     {
-        return x == other.x && y == other.y;
+        x -= rhs;
+        y -= rhs;
+        return *this;
+    }
+
+    vec2i& vec2i::operator*=(const vec2i& rhs)
+    {
+        x *= rhs.x;
+        y *= rhs.y;
+        return *this;
+    }
+
+    vec2i& vec2i::operator*=(const int32_t rhs)
+    {
+        x *= rhs;
+        y *= rhs;
+        return *this;
+    }
+
+    vec2i& vec2i::operator/=(const vec2i& rhs)
+    {
+        x /= rhs.x;
+        y /= rhs.y;
+        return *this;
+    }
+
+    vec2i& vec2i::operator/=(const int32_t rhs)
+    {
+        x /= rhs;
+        y /= rhs;
+        return *this;
+    }
+
+    bool vec2i::operator==(const vec2i& rhs) const
+    {
+        return x == rhs.x && y == rhs.y;
     }
 
     bool vec2i::operator!=(const vec2i& rhs) const
@@ -152,15 +210,6 @@ namespace hxm
 
 
     // VEC2U ----------------------------------------------------------------------
-    uint32_t& vec2u::operator[](uint32_t idx) {
-        return _v[idx];
-    }
-
-    uint32_t vec2u::operator[](uint32_t idx) const
-    {
-        return _v[idx];
-    }
-
     vec2u& vec2u::operator+=(const vec2u& rhs)
     {
         x += rhs.x;
@@ -168,10 +217,52 @@ namespace hxm
         return *this;
     }
 
+    vec2u& vec2u::operator+=(const uint32_t rhs)
+    {
+        x += rhs;
+        y += rhs;
+        return *this;
+    }
+
     vec2u& vec2u::operator-=(const vec2u& rhs)
     {
         x -= rhs.x;
         y -= rhs.y;
+        return *this;
+    }
+
+    vec2u& vec2u::operator-=(const uint32_t rhs)
+    {
+        x -= rhs;
+        y -= rhs;
+        return *this;
+    }
+
+    vec2u& vec2u::operator*=(const vec2u& rhs)
+    {
+        x *= rhs.x;
+        y *= rhs.y;
+        return *this;
+    }
+
+    vec2u& vec2u::operator*=(const uint32_t rhs)
+    {
+        x *= rhs;
+        y *= rhs;
+        return *this;
+    }
+
+    vec2u& vec2u::operator/=(const vec2u& rhs)
+    {
+        x /= rhs.x;
+        y /= rhs.y;
+        return *this;
+    }
+
+    vec2u& vec2u::operator/=(const uint32_t rhs)
+    {
+        x /= rhs;
+        y /= rhs;
         return *this;
     }
 
@@ -183,6 +274,16 @@ namespace hxm
     bool vec2u::operator!=(const vec2u& rhs) const
     {
         return x != rhs.x || y != rhs.y;
+    }
+
+    uint32_t& vec2u::operator[](uint32_t idx)
+    {
+        return _v[idx];
+    }
+
+    uint32_t vec2u::operator[](uint32_t idx) const
+    {
+        return _v[idx];
     }
 
     vec2u::vec2u() : x(0), y(0) {}
@@ -209,11 +310,27 @@ namespace hxm
         return *this;
     }
 
+    vec3f& vec3f::operator+=(const float rhs)
+    {
+        x += rhs;
+        y += rhs;
+        z += rhs;
+        return *this;
+    }
+
     vec3f& vec3f::operator-=(const vec3f& rhs)
     {
         x -= rhs.x;
         y -= rhs.y;
         z -= rhs.z;
+        return *this;
+    }
+
+    vec3f& vec3f::operator-=(const float rhs)
+    {
+        x -= rhs;
+        y -= rhs;
+        z -= rhs;
         return *this;
     }
 
@@ -225,7 +342,7 @@ namespace hxm
         return *this;
     }
 
-    vec3f& vec3f::operator*=(float rhs)
+    vec3f& vec3f::operator*=(const float rhs)
     {
         x *= rhs;
         y *= rhs;
@@ -241,22 +358,12 @@ namespace hxm
         return *this;
     }
 
-    vec3f& vec3f::operator/=(float rhs)
+    vec3f& vec3f::operator/=(const float rhs)
     {
         x /= rhs;
         y /= rhs;
         z /= rhs;
         return *this;
-    }
-
-    float& vec3f::operator[](uint32_t idx)
-    {
-        return _v[idx];
-    }
-
-    float vec3f::operator[](uint32_t idx) const
-    {
-        return _v[idx];
     }
 
     bool vec3f::operator==(const vec3f& rhs) const
@@ -267,6 +374,16 @@ namespace hxm
     bool vec3f::operator!=(const vec3f& rhs) const
     {
         return x != rhs.x || y != rhs.y || z != rhs.z;
+    }
+
+    float& vec3f::operator[](uint32_t idx)
+    {
+        return _v[idx];
+    }
+
+    float vec3f::operator[](uint32_t idx) const
+    {
+        return _v[idx];
     }
 
     uint32_t vec3f::minCompIdx() const
@@ -295,12 +412,14 @@ namespace hxm
 
     float vec3f::length() const
     {
-        return sqrt(this->dot(*this));
+        return std::sqrt((x * x) + (y * y) + (z * z));
     }
 
-    vec3f& vec3f::normalize()
+    float vec3f::normalize()
     {
-        return (*this) /= (length());
+        const float len = length();
+        (*this) /= len;
+        return len;
     }
 
     vec3f::vec3f() : x(0), y(0), z(0) {}
@@ -322,11 +441,59 @@ namespace hxm
         return *this;
     }
 
+    vec3i& vec3i::operator+=(const int32_t rhs)
+    {
+        x += rhs;
+        y += rhs;
+        z += rhs;
+        return *this;
+    }
+
     vec3i& vec3i::operator-=(const vec3i& rhs)
     {
         x -= rhs.x;
         y -= rhs.y;
         z -= rhs.z;
+        return *this;
+    }
+
+    vec3i& vec3i::operator-=(const int32_t rhs)
+    {
+        x -= rhs;
+        y -= rhs;
+        z -= rhs;
+        return *this;
+    }
+
+    vec3i& vec3i::operator*=(const vec3i& rhs)
+    {
+        x *= rhs.x;
+        y *= rhs.y;
+        z *= rhs.z;
+        return *this;
+    }
+
+    vec3i& vec3i::operator*=(const int32_t rhs)
+    {
+        x *= rhs;
+        y *= rhs;
+        z *= rhs;
+        return *this;
+    }
+
+    vec3i& vec3i::operator/=(const vec3i& rhs)
+    {
+        x /= rhs.x;
+        y /= rhs.y;
+        z /= rhs.z;
+        return *this;
+    }
+
+    vec3i& vec3i::operator/=(const int32_t rhs)
+    {
+        x /= rhs;
+        y /= rhs;
+        z /= rhs;
         return *this;
     }
 
@@ -358,14 +525,68 @@ namespace hxm
 
 
     // VEC3U ----------------------------------------------------------------------
-    uint32_t& vec3u::operator[](uint32_t idx)
+    vec3u& vec3u::operator+=(const vec3u& rhs)
     {
-        return _v[idx];
+        x += rhs.x;
+        y += rhs.y;
+        z += rhs.z;
+        return *this;
     }
 
-    uint32_t vec3u::operator[](uint32_t idx) const
+    vec3u& vec3u::operator+=(const uint32_t rhs)
     {
-        return _v[idx];
+        x += rhs;
+        y += rhs;
+        z += rhs;
+        return *this;
+    }
+
+    vec3u& vec3u::operator-=(const vec3u& rhs)
+    {
+        x -= rhs.x;
+        y -= rhs.y;
+        z -= rhs.z;
+        return *this;
+    }
+
+    vec3u& vec3u::operator-=(const uint32_t rhs)
+    {
+        x -= rhs;
+        y -= rhs;
+        z -= rhs;
+        return *this;
+    }
+
+    vec3u& vec3u::operator*=(const vec3u& rhs)
+    {
+        x *= rhs.x;
+        y *= rhs.y;
+        z *= rhs.z;
+        return *this;
+    }
+
+    vec3u& vec3u::operator*=(const uint32_t rhs)
+    {
+        x *= rhs;
+        y *= rhs;
+        z *= rhs;
+        return *this;
+    }
+
+    vec3u& vec3u::operator/=(const vec3u& rhs)
+    {
+        x /= rhs.x;
+        y /= rhs.y;
+        z /= rhs.z;
+        return *this;
+    }
+
+    vec3u& vec3u::operator/=(const uint32_t rhs)
+    {
+        x /= rhs;
+        y /= rhs;
+        z /= rhs;
+        return *this;
     }
 
     bool vec3u::operator==(const vec3u& rhs) const
@@ -376,6 +597,16 @@ namespace hxm
     bool vec3u::operator!=(const vec3u& rhs) const
     {
         return !(x == rhs.x && y == rhs.y && z == rhs.z);
+    }
+
+    uint32_t& vec3u::operator[](uint32_t idx)
+    {
+        return _v[idx];
+    }
+
+    uint32_t vec3u::operator[](uint32_t idx) const
+    {
+        return _v[idx];
     }
 
     vec3u::vec3u() : x(0), y(0), z(0) {}
@@ -396,14 +627,68 @@ namespace hxm
 
 
     // VEC3U8 ---------------------------------------------------------------------
-    uint8_t& vec3u8::operator[](uint32_t idx)
+    vec3u8& vec3u8::operator+=(const vec3u8& rhs)
     {
-        return _v[idx];
+        x += rhs.x;
+        y += rhs.y;
+        z += rhs.z;
+        return *this;
     }
 
-    uint8_t vec3u8::operator[](uint32_t idx) const
+    vec3u8& vec3u8::operator+=(const uint8_t rhs)
     {
-        return _v[idx];
+        x += rhs;
+        y += rhs;
+        z += rhs;
+        return *this;
+    }
+
+    vec3u8& vec3u8::operator-=(const vec3u8& rhs)
+    {
+        x -= rhs.x;
+        y -= rhs.y;
+        z -= rhs.z;
+        return *this;
+    }
+
+    vec3u8& vec3u8::operator-=(const uint8_t rhs)
+    {
+        x -= rhs;
+        y -= rhs;
+        z -= rhs;
+        return *this;
+    }
+
+    vec3u8& vec3u8::operator*=(const vec3u8& rhs)
+    {
+        x *= rhs.x;
+        y *= rhs.y;
+        z *= rhs.z;
+        return *this;
+    }
+
+    vec3u8& vec3u8::operator*=(const uint8_t rhs)
+    {
+        x *= rhs;
+        y *= rhs;
+        z *= rhs;
+        return *this;
+    }
+
+    vec3u8& vec3u8::operator/=(const vec3u8& rhs)
+    {
+        x /= rhs.x;
+        y /= rhs.y;
+        z /= rhs.z;
+        return *this;
+    }
+
+    vec3u8& vec3u8::operator/=(const uint8_t rhs)
+    {
+        x /= rhs;
+        y /= rhs;
+        z /= rhs;
+        return *this;
     }
 
     bool vec3u8::operator==(const vec3u8& rhs) const
@@ -414,6 +699,16 @@ namespace hxm
     bool vec3u8::operator!=(const vec3u8& rhs) const
     {
         return !(x == rhs.x && y == rhs.y && z == rhs.z);
+    }
+
+    uint8_t& vec3u8::operator[](uint32_t idx)
+    {
+        return _v[idx];
+    }
+
+    uint8_t vec3u8::operator[](uint32_t idx) const
+    {
+        return _v[idx];
     }
 
     vec3u8::vec3u8() : x(0), y(0), z(0) {}
@@ -449,12 +744,30 @@ namespace hxm
         return *this;
     }
 
+    vec4f& vec4f::operator+=(const float rhs)
+    {
+        x += rhs;
+        y += rhs;
+        z += rhs;
+        w += rhs;
+        return *this;
+    }
+
     vec4f& vec4f::operator-=(const vec4f& rhs)
     {
         x -= rhs.x;
         y -= rhs.y;
         z -= rhs.z;
         w -= rhs.w;
+        return *this;
+    }
+
+    vec4f& vec4f::operator-=(const float rhs)
+    {
+        x -= rhs;
+        y -= rhs;
+        z -= rhs;
+        w -= rhs;
         return *this;
     }
 
@@ -467,7 +780,7 @@ namespace hxm
         return *this;
     }
 
-    vec4f& vec4f::operator*=(float rhs)
+    vec4f& vec4f::operator*=(const float rhs)
     {
         x *= rhs;
         y *= rhs;
@@ -485,7 +798,7 @@ namespace hxm
         return *this;
     }
 
-    vec4f& vec4f::operator/=(float rhs)
+    vec4f& vec4f::operator/=(const float rhs)
     {
         x /= rhs;
         y /= rhs;
@@ -514,6 +827,7 @@ namespace hxm
         return _v[idx];
     }
 
+    // TODO jjensen: remove copy and set
     vec4f& vec4f::copy(const vec4f& v)
     {
         x = v.x;
@@ -572,14 +886,15 @@ namespace hxm
 
     float vec4f::length() const
     {
-        return sqrt(this->dot(*this));
+        return std::sqrt((x * x) + (y * y) + (z * z) + (w * w));
     }
 
-    vec4f& vec4f::normalize()
+    float vec4f::normalize()
     {
-        return (*this) /= (length());
+        const float len = length();
+        (*this) /= len;
+        return len;
     }
-
 
 
     vec4f::vec4f() : x(0), y(0), z(0), w(0) {}
@@ -601,12 +916,30 @@ namespace hxm
         return *this;
     }
 
+    vec4i& vec4i::operator+=(const int32_t rhs)
+    {
+        x += rhs;
+        y += rhs;
+        z += rhs;
+        w += rhs;
+        return *this;
+    }
+
     vec4i& vec4i::operator-=(const vec4i& rhs)
     {
         x -= rhs.x;
         y -= rhs.y;
         z -= rhs.z;
         w -= rhs.w;
+        return *this;
+    }
+
+    vec4i& vec4i::operator-=(const int32_t rhs)
+    {
+        x -= rhs;
+        y -= rhs;
+        z -= rhs;
+        w -= rhs;
         return *this;
     }
 
@@ -619,23 +952,31 @@ namespace hxm
         return *this;
     }
 
-    vec4i& vec4i::operator+=(int value)
+    vec4i& vec4i::operator*=(const int32_t rhs)
     {
-        x += value;
-        y += value;
-        z += value;
-        w += value;
+        x *= rhs;
+        y *= rhs;
+        z *= rhs;
+        w *= rhs;
         return *this;
     }
 
-    int32_t& vec4i::operator[](uint32_t idx)
+    vec4i& vec4i::operator/=(const vec4i& rhs)
     {
-        return _v[idx];
+        x /= rhs.x;
+        y /= rhs.y;
+        z /= rhs.z;
+        w /= rhs.w;
+        return *this;
     }
 
-    int32_t vec4i::operator[](uint32_t idx) const
+    vec4i& vec4i::operator/=(const int32_t rhs)
     {
-        return _v[idx];
+        x /= rhs;
+        y /= rhs;
+        z /= rhs;
+        w /= rhs;
+        return *this;
     }
 
     bool vec4i::operator==(const vec4i& other) const
@@ -653,33 +994,115 @@ namespace hxm
         return x == other.x && y == other.y && z == other.z && w == other.w;
     }
 
+    int32_t& vec4i::operator[](uint32_t idx)
+    {
+        return _v[idx];
+    }
+
+    int32_t vec4i::operator[](uint32_t idx) const
+    {
+        return _v[idx];
+    }
+
     vec4i::vec4i() : x(0), y(0), z(0), w(0) {}
     vec4i::vec4i(int32_t v) : x(v), y(v), z(v), w(v) {}
     vec4i::vec4i(int32_t x, int32_t y, int32_t z, int32_t w) : x(x), y(y), z(z), w(w) {}
     vec4i::vec4i(const vec4f& fvec)
     {
-        x = (int32_t)fvec.x;
-        y = (int32_t)fvec.y;
-        z = (int32_t)fvec.z;
-        w = (int32_t)fvec.w;
+        x = int32_t(fvec.x);
+        y = int32_t(fvec.y);
+        z = int32_t(fvec.z);
+        w = int32_t(fvec.w);
     }
     vec4i::vec4i(const vec4u& uvec)
     {
-        x = (int32_t)uvec.x;
-        y = (int32_t)uvec.y;
-        z = (int32_t)uvec.z;
-        w = (int32_t)uvec.w;
+        x = int32_t(uvec.x);
+        y = int32_t(uvec.y);
+        z = int32_t(uvec.z);
+        w = int32_t(uvec.w);
     }
 
     // VEC4U ----------------------------------------------------------------------
-    uint32_t& vec4u::operator[](uint32_t idx)
+    vec4u& vec4u::operator+=(const vec4u& rhs)
     {
-        return _v[idx];
+        x += rhs.x;
+        y += rhs.y;
+        z += rhs.z;
+        w += rhs.w;
+        return *this;
     }
 
-    uint32_t vec4u::operator[](uint32_t idx) const
+    vec4u& vec4u::operator+=(const uint32_t rhs)
     {
-        return _v[idx];
+        x += rhs;
+        y += rhs;
+        z += rhs;
+        w += rhs;
+        return *this;
+    }
+
+    vec4u& vec4u::operator-=(const vec4u& rhs)
+    {
+        x -= rhs.x;
+        y -= rhs.y;
+        z -= rhs.z;
+        w -= rhs.w;
+        return *this;
+    }
+
+    vec4u& vec4u::operator-=(const uint32_t rhs)
+    {
+        x -= rhs;
+        y -= rhs;
+        z -= rhs;
+        w -= rhs;
+        return *this;
+    }
+
+    vec4u& vec4u::operator*=(const vec4u& rhs)
+    {
+        x *= rhs.x;
+        y *= rhs.y;
+        z *= rhs.z;
+        w *= rhs.w;
+        return *this;
+    }
+
+    vec4u& vec4u::operator*=(const uint32_t rhs)
+    {
+        x *= rhs;
+        y *= rhs;
+        z *= rhs;
+        w *= rhs;
+        return *this;
+    }
+
+    // integer division
+    vec4u& vec4u::operator/=(const vec4u& rhs)
+    {
+        x /= rhs.x;
+        y /= rhs.y;
+        z /= rhs.z;
+        w /= rhs.w;
+        return *this;
+    }
+
+    vec4u& vec4u::operator/=(const uint32_t rhs)
+    {
+        x /= rhs;
+        y /= rhs;
+        z /= rhs;
+        w /= rhs;
+        return *this;
+    }
+
+    vec4u& vec4u::operator%=(const uint32_t rhs)
+    {
+        x %= rhs;
+        y %= rhs;
+        z %= rhs;
+        w %= rhs;
+        return *this;
     }
 
     bool vec4u::operator==(const vec4u& other) const
@@ -697,59 +1120,14 @@ namespace hxm
         return x != other.x || y != other.y || z != other.z || w != other.w;
     }
 
-    // integer division
-    vec4u& vec4u::operator/=(size_t value)
+    uint32_t& vec4u::operator[](uint32_t idx)
     {
-        x /= value;
-        y /= value;
-        z /= value;
-        w /= value;
-        return *this;
+        return _v[idx];
     }
 
-    vec4u& vec4u::operator%=(size_t value)
+    uint32_t vec4u::operator[](uint32_t idx) const
     {
-        x %= value;
-        y %= value;
-        z %= value;
-        w %= value;
-        return *this;
-    }
-
-    vec4u& vec4u::operator+=(size_t rhs)
-    {
-        x += rhs;
-        y += rhs;
-        z += rhs;
-        w += rhs;
-        return *this;
-    }
-
-    vec4u& vec4u::operator+=(const vec4u& other)
-    {
-        x += other.x;
-        y += other.y;
-        z += other.z;
-        w += other.w;
-        return *this;
-    }
-
-    vec4u& vec4u::operator-=(const vec4u& rhs)
-    {
-        x -= rhs.x;
-        y -= rhs.y;
-        z -= rhs.z;
-        w -= rhs.w;
-        return *this;
-    }
-
-    vec4u& vec4u::operator-=(const int& rhs)
-    {
-        x -= rhs;
-        y -= rhs;
-        z -= rhs;
-        w -= rhs;
-        return *this;
+        return _v[idx];
     }
 
     vec4u::vec4u() : x(0), y(0), z(0), w(0) {}
@@ -772,41 +1150,21 @@ namespace hxm
 
 
     // VEC4U8 ---------------------------------------------------------------------
-    uint8_t& vec4u8::operator[](uint32_t idx)
+    vec4u8& vec4u8::operator+=(const vec4u8& rhs)
     {
-        return _v[idx];
+        x += rhs.x;
+        y += rhs.y;
+        z += rhs.z;
+        w += rhs.w;
+        return *this;
     }
 
-    uint8_t vec4u8::operator[](uint32_t idx) const
-    {
-        return _v[idx];
-    }
-
-    bool vec4u8::operator==(const vec4u8& other) const
-    {
-        return x == other.x && y == other.y && z == other.z && w == other.w;
-    }
-
-    bool vec4u8::operator!=(const vec4u8& other) const
-    {
-        return x != other.x || y != other.y || z != other.z || w != other.w;
-    }
-
-    vec4u8& vec4u8::operator+=(size_t rhs)
+    vec4u8& vec4u8::operator+=(const uint8_t rhs)
     {
         x += rhs;
         y += rhs;
         z += rhs;
         w += rhs;
-        return *this;
-    }
-
-    vec4u8& vec4u8::operator+=(const vec4u8& other)
-    {
-        x += other.x;
-        y += other.y;
-        z += other.z;
-        w += other.w;
         return *this;
     }
 
@@ -819,13 +1177,69 @@ namespace hxm
         return *this;
     }
 
-    vec4u8& vec4u8::operator-=(const int& rhs)
+    vec4u8& vec4u8::operator-=(const uint8_t rhs)
     {
         x -= rhs;
         y -= rhs;
         z -= rhs;
         w -= rhs;
         return *this;
+    }
+
+    vec4u8& vec4u8::operator*=(const vec4u8& rhs)
+    {
+        x *= rhs.x;
+        y *= rhs.y;
+        z *= rhs.z;
+        w *= rhs.w;
+        return *this;
+    }
+
+    vec4u8& vec4u8::operator*=(const uint8_t rhs)
+    {
+        x *= rhs;
+        y *= rhs;
+        z *= rhs;
+        w *= rhs;
+        return *this;
+    }
+
+    vec4u8& vec4u8::operator/=(const vec4u8& rhs)
+    {
+        x /= rhs.x;
+        y /= rhs.y;
+        z /= rhs.z;
+        w /= rhs.w;
+        return *this;
+    }
+
+    vec4u8& vec4u8::operator/=(const uint8_t rhs)
+    {
+        x /= rhs;
+        y /= rhs;
+        z /= rhs;
+        w /= rhs;
+        return *this;
+    }
+
+    bool vec4u8::operator==(const vec4u8& other) const
+    {
+        return x == other.x && y == other.y && z == other.z && w == other.w;
+    }
+
+    bool vec4u8::operator!=(const vec4u8& other) const
+    {
+        return x != other.x || y != other.y || z != other.z || w != other.w;
+    }
+
+    uint8_t& vec4u8::operator[](uint32_t idx)
+    {
+        return _v[idx];
+    }
+
+    uint8_t vec4u8::operator[](uint32_t idx) const
+    {
+        return _v[idx];
     }
 
     vec4u8::vec4u8() : x(0), y(0), z(0), w(0) {}
@@ -865,7 +1279,7 @@ namespace hxm
         return *this;
     }
 
-    vec5f& vec5f::operator+=(float rhs)
+    vec5f& vec5f::operator+=(const float rhs)
     {
         x += rhs;
         y += rhs;
@@ -885,7 +1299,7 @@ namespace hxm
         return *this;
     }
 
-    vec5f& vec5f::operator-=(float rhs)
+    vec5f& vec5f::operator-=(const float rhs)
     {
         x -= rhs;
         y -= rhs;
@@ -905,7 +1319,7 @@ namespace hxm
         return *this;
     }
 
-    vec5f& vec5f::operator*=(float rhs)
+    vec5f& vec5f::operator*=(const float rhs)
     {
         x *= rhs;
         y *= rhs;
@@ -925,7 +1339,7 @@ namespace hxm
         return *this;
     }
 
-    vec5f& vec5f::operator/=(float rhs)
+    vec5f& vec5f::operator/=(const float rhs)
     {
         x /= rhs;
         y /= rhs;
@@ -955,6 +1369,7 @@ namespace hxm
         return _v[idx];
     }
 
+    // TODO jjensen: remove copy and set
     vec5f& vec5f::copy(const vec5f& v)
     {
         this->x = v.x;
@@ -1021,12 +1436,14 @@ namespace hxm
 
     float vec5f::length() const
     {
-        return sqrt(this->dot(*this));
+        return std::sqrt((x * x) + (y * y) + (z * z) + (w * w) + (v * v));
     }
 
-    vec5f& vec5f::normalize()
+    float vec5f::normalize()
     {
-        return (*this) /= (length());
+        const float len = length();
+        (*this) /= len;
+        return len;
     }
 
     vec5f::vec5f() : x(0), y(0), z(0), w(0), v(0) {}
@@ -1051,6 +1468,16 @@ namespace hxm
         return *this;
     }
 
+    vec5i& vec5i::operator+=(const int32_t value)
+    {
+        x += value;
+        y += value;
+        z += value;
+        w += value;
+        v += value;
+        return *this;
+    }
+
     vec5i& vec5i::operator-=(const vec5i& rhs)
     {
         x -= rhs.x;
@@ -1061,13 +1488,53 @@ namespace hxm
         return *this;
     }
 
-    vec5i& vec5i::operator+=(int value)
+    vec5i& vec5i::operator-=(const int32_t rhs)
     {
-        x += value;
-        y += value;
-        z += value;
-        w += value;
-        v += value;
+        x -= rhs;
+        y -= rhs;
+        z -= rhs;
+        w -= rhs;
+        v -= rhs;
+        return *this;
+    }
+
+    vec5i& vec5i::operator*=(const vec5i& rhs)
+    {
+        x *= rhs.x;
+        y *= rhs.y;
+        z *= rhs.z;
+        w *= rhs.w;
+        v *= rhs.v;
+        return *this;
+    }
+
+    vec5i& vec5i::operator*=(const int32_t rhs)
+    {
+        x *= rhs;
+        y *= rhs;
+        z *= rhs;
+        w *= rhs;
+        v *= rhs;
+        return *this;
+    }
+
+    vec5i& vec5i::operator/=(const vec5i& rhs)
+    {
+        x /= rhs.x;
+        y /= rhs.y;
+        z /= rhs.z;
+        w /= rhs.w;
+        v /= rhs.v;
+        return *this;
+    }
+
+    vec5i& vec5i::operator/=(const int32_t rhs)
+    {
+        x /= rhs;
+        y /= rhs;
+        z /= rhs;
+        w /= rhs;
+        v /= rhs;
         return *this;
     }
 
@@ -1094,4 +1561,126 @@ namespace hxm
     vec5i::vec5i() : x(0), y(0), z(0), w(0), v(0) {}
     vec5i::vec5i(int32_t v) : x(v), y(v), z(v), w(v), v(v) {}
     vec5i::vec5i(int32_t x, int32_t y, int32_t z, int32_t w, int32_t v) : x(x), y(y), z(z), w(w), v(v) {}
+
+    // VEC5U ----------------------------------------------------------------------
+    vec5u& vec5u::operator+=(const vec5u& rhs)
+    {
+        x += rhs.x;
+        y += rhs.y;
+        z += rhs.z;
+        w += rhs.w;
+        v += rhs.v;
+        return *this;
+    }
+
+    vec5u& vec5u::operator+=(const uint32_t rhs)
+    {
+        x += rhs;
+        y += rhs;
+        z += rhs;
+        w += rhs;
+        v += rhs;
+        return *this;
+    }
+
+    vec5u& vec5u::operator-=(const vec5u& rhs)
+    {
+        x -= rhs.x;
+        y -= rhs.y;
+        z -= rhs.z;
+        w -= rhs.w;
+        v -= rhs.v;
+        return *this;
+    }
+
+    vec5u& vec5u::operator-=(const uint32_t rhs)
+    {
+        x -= rhs;
+        y -= rhs;
+        z -= rhs;
+        w -= rhs;
+        v -= rhs;
+        return *this;
+    }
+
+    vec5u& vec5u::operator*=(const vec5u& rhs)
+    {
+        x *= rhs.x;
+        y *= rhs.y;
+        z *= rhs.z;
+        w *= rhs.w;
+        v *= rhs.v;
+        return *this;
+    }
+
+    vec5u& vec5u::operator*=(const uint32_t rhs)
+    {
+        x *= rhs;
+        y *= rhs;
+        z *= rhs;
+        w *= rhs;
+        v *= rhs;
+        return *this;
+    }
+
+    // integer division
+    vec5u& vec5u::operator/=(const vec5u& rhs)
+    {
+        x /= rhs.x;
+        y /= rhs.y;
+        z /= rhs.z;
+        w /= rhs.w;
+        v /= rhs.v;
+        return *this;
+    }
+
+    vec5u& vec5u::operator/=(const uint32_t rhs)
+    {
+        x /= rhs;
+        y /= rhs;
+        z /= rhs;
+        w /= rhs;
+        v /= rhs;
+        return *this;
+    }
+
+    bool vec5u::operator==(const vec5u& other) const
+    {
+        return x == other.x && y == other.y && z == other.z && w == other.w;
+    }
+
+    bool vec5u::operator!=(const vec5u& other) const
+    {
+        return x != other.x || y != other.y || z != other.z || w != other.w;
+    }
+
+    uint32_t& vec5u::operator[](uint32_t idx)
+    {
+        return _v[idx];
+    }
+
+    uint32_t vec5u::operator[](uint32_t idx) const
+    {
+        return _v[idx];
+    }
+
+    vec5u::vec5u() : x(0), y(0), z(0), w(0), v(0) {}
+    vec5u::vec5u(uint32_t v) : x(v), y(v), z(v), w(v), v(v) {}
+    vec5u::vec5u(uint32_t x, uint32_t y, uint32_t z, uint32_t w, uint32_t v) : x(x), y(y), z(z), w(w), v(v) {}
+    vec5u::vec5u(const vec5f& vec)
+    {
+        x = uint32_t(std::max(0.0f, vec.x));
+        y = uint32_t(std::max(0.0f, vec.y));
+        z = uint32_t(std::max(0.0f, vec.z));
+        w = uint32_t(std::max(0.0f, vec.w));
+        v = uint32_t(std::max(0.0f, vec.v));
+    }
+    vec5u::vec5u(const vec5i& ivec)
+    {
+        x = std::max(0, ivec.x);
+        y = std::max(0, ivec.y);
+        z = std::max(0, ivec.z);
+        w = std::max(0, ivec.w);
+        v = std::max(0, ivec.v);
+    }
 }

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -87,19 +87,6 @@ namespace hxm
         return _v[idx];
     }
 
-    uint32_t vec2f::minCompIdx() const
-    {
-        uint32_t minIdx = 0;
-        float minVal = x;
-        if (y < minVal)
-        {
-            minIdx = 1;
-            minVal = y;
-        }
-
-        return minIdx;
-    }
-
     float vec2f::dot(const vec2f& rhs) const
     {
         return (x * rhs.x) + (y * rhs.y);
@@ -384,25 +371,6 @@ namespace hxm
     float vec3f::operator[](uint32_t idx) const
     {
         return _v[idx];
-    }
-
-    uint32_t vec3f::minCompIdx() const
-    {
-        uint32_t minIdx = 0;
-        float minVal = x;
-        if (y < minVal)
-        {
-            minIdx = 1;
-            minVal = y;
-        }
-
-        if (z < minVal)
-        {
-            minIdx = 2;
-            minVal = z;
-        }
-
-        return minIdx;
     }
 
     float vec3f::dot(const vec3f& rhs) const
@@ -825,39 +793,6 @@ namespace hxm
     float vec4f::operator[](uint32_t idx) const
     {
         return _v[idx];
-    }
-
-    uint32_t vec4f::minCompIdx() const
-    {
-        uint32_t minIdx = 0;
-        float minVal = FLT_MAX;
-
-        // don't consider components with -infinity values
-        if (!std::isinf(x) && x < minVal)
-        {
-            minIdx = 0;
-            minVal = x;
-        }
-
-        if (!std::isinf(y) && y < minVal)
-        {
-            minIdx = 1;
-            minVal = y;
-        }
-
-        if (!std::isinf(z) && z < minVal)
-        {
-            minIdx = 2;
-            minVal = z;
-        }
-
-        if (!std::isinf(w) && w < minVal)
-        {
-            minIdx = 3;
-            minVal = w;
-        }
-
-        return minIdx;
     }
 
     float vec4f::dot(const vec4f& rhs) const
@@ -1348,45 +1283,6 @@ namespace hxm
     float vec5f::operator[](uint32_t idx) const
     {
         return _v[idx];
-    }
-
-    uint32_t vec5f::minCompIdx() const
-    {
-        uint32_t minIdx = 0;
-        float minVal = FLT_MAX;
-
-        // don't consider components with -infinity values
-        if (!std::isinf(x) && x < minVal)
-        {
-            minIdx = 0;
-            minVal = x;
-        }
-
-        if (!std::isinf(y) && y < minVal)
-        {
-            minIdx = 1;
-            minVal = y;
-        }
-
-        if (!std::isinf(z) && z < minVal)
-        {
-            minIdx = 2;
-            minVal = z;
-        }
-
-        if (!std::isinf(w) && w < minVal)
-        {
-            minIdx = 3;
-            minVal = w;
-        }
-
-        if (!std::isinf(v) && v < minVal)
-        {
-            minIdx = 4;
-            minVal = v;
-        }
-
-        return minIdx;
     }
 
     float vec5f::dot(const vec5f& rhs) const

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -827,25 +827,6 @@ namespace hxm
         return _v[idx];
     }
 
-    // TODO jjensen: remove copy and set
-    vec4f& vec4f::copy(const vec4f& v)
-    {
-        x = v.x;
-        y = v.y;
-        z = v.z;
-        w = v.w;
-        return *this;
-    }
-
-    vec4f& vec4f::set(float x, float y, float z, float w)
-    {
-        this->x = x;
-        this->y = y;
-        this->z = z;
-        this->w = w;
-        return *this;
-    }
-
     uint32_t vec4f::minCompIdx() const
     {
         uint32_t minIdx = 0;
@@ -1367,27 +1348,6 @@ namespace hxm
     float vec5f::operator[](uint32_t idx) const
     {
         return _v[idx];
-    }
-
-    // TODO jjensen: remove copy and set
-    vec5f& vec5f::copy(const vec5f& v)
-    {
-        this->x = v.x;
-        this->y = v.y;
-        this->z = v.z;
-        this->w = v.w;
-        this->v = v.v;
-        return *this;
-    }
-
-    vec5f& vec5f::set(float x, float y, float z, float w, float v)
-    {
-        this->x = x;
-        this->y = y;
-        this->z = z;
-        this->w = w;
-        this->v = v;
-        return *this;
     }
 
     uint32_t vec5f::minCompIdx() const

--- a/src/vec.h
+++ b/src/vec.h
@@ -886,10 +886,6 @@ namespace hxm
         float& operator[](uint32_t idx);
         float operator[](uint32_t idx) const;
 
-        // TODO jjensen: remove copy and set
-        vec4f& copy(const vec4f& v);
-        vec4f& set(float x, float y, float z, float w);
-
         uint32_t minCompIdx() const;    // the index of the smallest component of this vector
         float dot(const vec4f& rhs) const;
         float length() const;
@@ -1463,10 +1459,6 @@ namespace hxm
         bool operator!=(const vec5f& other) const;
         float& operator[](uint32_t idx);
         float operator[](uint32_t idx) const;
-
-        // TODO jjensen: remove copy and set
-        vec5f& copy(const vec5f& v);
-        vec5f& set(float x, float y, float z, float w, float v);
 
         uint32_t minCompIdx() const;    // the index of the smallest component of this vector
         float dot(const vec5f& rhs) const;

--- a/src/vec.h
+++ b/src/vec.h
@@ -71,9 +71,6 @@ namespace hxm
         float length() const;
         float normalize();  // returns the length before normalization
 
-        // TODO: move to utils file
-        uint32_t minCompIdx() const;    // the index of the smallest component of this vector
-
         vec2f();
         vec2f(float v);
         vec2f(float x, float y);
@@ -454,9 +451,6 @@ namespace hxm
         float& operator[](uint32_t idx);
         float  operator[](uint32_t idx) const;
 
-        // TODO move to utils file
-        uint32_t minCompIdx() const;    // the index of the smallest component of this vector
-        
         float dot(const vec3f& rhs) const;
         float length() const;
         float normalize(); // returns the length before normalization
@@ -886,7 +880,6 @@ namespace hxm
         float& operator[](uint32_t idx);
         float operator[](uint32_t idx) const;
 
-        uint32_t minCompIdx() const;    // the index of the smallest component of this vector
         float dot(const vec4f& rhs) const;
         float length() const;
         float normalize();  // returns length before normalization
@@ -1008,7 +1001,7 @@ namespace hxm
 
     inline vec4f round(const vec4f& v)
     {
-        return vec4f(std::roundf(v.x), std::roundf(v.y), std::roundf(v.z), std::roundf(v.w));
+        return vec4f(std::round(v.x), std::round(v.y), std::round(v.z), std::round(v.w));
     }
 
     inline vec4f vabs(vec4f v)
@@ -1138,20 +1131,6 @@ namespace hxm
         v.z = std::abs(v.z);
         v.w = std::abs(v.w);
         return v;
-    }
-
-    // TODO: move to utils file?
-    inline int firstNonZeroComponent(const vec4i& v)
-    {
-        for (int idx = 0; idx < 4; idx++)
-        {
-            if (v[idx] != 0)
-            {
-                return idx;
-            }
-        }
-
-        return -1;
     }
 
     // handles negative values in vec a
@@ -1313,18 +1292,6 @@ namespace hxm
         return lhs;
     }
 
-    // TODO: move to a utils file?
-    inline size_t countEqualComponents(const vec4u& a, const vec4u& b)
-    {
-        size_t result = 0;
-        result += a.x == b.x ? 1 : 0;
-        result += a.y == b.y ? 1 : 0;
-        result += a.z == b.z ? 1 : 0;
-        result += a.w == b.w ? 1 : 0;
-        return result;
-    }
-
-
     // VEC4U8 -----------------------------------------------------------------
     class vec4u8 {
         // Members
@@ -1460,7 +1427,6 @@ namespace hxm
         float& operator[](uint32_t idx);
         float operator[](uint32_t idx) const;
 
-        uint32_t minCompIdx() const;    // the index of the smallest component of this vector
         float dot(const vec5f& rhs) const;
         float length() const;
         float normalize();  // returns length before normalization
@@ -1694,20 +1660,6 @@ namespace hxm
         v.w = std::abs(v.w);
         v.v = std::abs(v.v);
         return v;
-    }
-
-    // TODO: move to a utils file?
-    inline int firstNonZeroComponent(const vec5i& v)
-    {
-        for (int idx = 0; idx < 5; idx++)
-        {
-            if (v[idx] != 0)
-            {
-                return idx;
-            }
-        }
-
-        return -1;
     }
 
     // handles negative values in vec a

--- a/src/vec.h
+++ b/src/vec.h
@@ -28,6 +28,7 @@ namespace hxm
     class vec4u8;
     class vec5f;
     class vec5i;
+    class vec5u;
 
     typedef vec3f colorRGB;
     typedef vec4f colorRGBA;
@@ -54,32 +55,42 @@ namespace hxm
     protected:
     public:
         vec2f& operator+=(const vec2f& rhs);
+        vec2f& operator+=(const float rhs);
         vec2f& operator-=(const vec2f& rhs);
+        vec2f& operator-=(const float rhs);
         vec2f& operator*=(const vec2f& rhs);
-        vec2f& operator*=(float rhs);
+        vec2f& operator*=(const float rhs);
         vec2f& operator/=(const vec2f& rhs);
-        vec2f& operator/=(float rhs);
+        vec2f& operator/=(const float rhs);
         bool operator==(const vec2f& rhs) const;
         bool operator!=(const vec2f& rhs) const;
         float& operator[](uint32_t idx);
         float operator[](uint32_t idx) const;
 
-        uint32_t minCompIdx() const;    // the index of the smallest component of this vector
         float dot(const vec2f& rhs) const;
         float length() const;
-        vec2f& normalize();
+        float normalize();  // returns the length before normalization
+
+        // TODO: move to utils file
+        uint32_t minCompIdx() const;    // the index of the smallest component of this vector
 
         vec2f();
         vec2f(float v);
         vec2f(float x, float y);
-        vec2f(const vec3f& v);
-        vec2f(const vec2i& v);
-        vec2f(const vec2u& v);
+        vec2f(const vec3f& fvec3);
+        vec2f(const vec2i& ivec);
+        vec2f(const vec2u& uvec);
     };
 
     inline vec2f operator+(vec2f lhs, const vec2f& rhs)
     {
         lhs += rhs;
+        return lhs;
+    }
+
+    inline vec2f operator+(vec2f lhs, const float rhs)
+    {
+        lhs += rhs; // TODO: would it be faster to unroll += ?
         return lhs;
     }
 
@@ -89,6 +100,13 @@ namespace hxm
         return lhs;
     }
 
+    inline vec2f operator-(vec2f lhs, const float rhs)
+    {
+        lhs -= rhs;
+        return lhs;
+    }
+
+    // negation operator
     inline vec2f operator-(const vec2f& rhs)
     {
         return vec2f(-rhs.x, -rhs.y);
@@ -126,8 +144,34 @@ namespace hxm
     inline vec2f normalize(const vec2f& v)
     {
         vec2f result = v;
-        result /= v.length();
+        result /= v.length();   // TODO: would it be faster to inline length()?
         return result;
+    }
+
+    inline vec2f clamp(vec2f v, const vec2f& vMin, const vec2f& vMax)
+    {
+        v.x = std::max(std::min(v.x, vMax.x), vMin.x);
+        v.y = std::max(std::min(v.y, vMax.y), vMin.y);
+        return v;
+    }
+
+    inline vec2f clamp(vec2f v, const float vMin, const float vMax)
+    {
+        v.x = std::max(std::min(v.x, vMax), vMin);
+        v.y = std::max(std::min(v.y, vMax), vMin);
+        return v;
+    }
+
+    inline vec2f round(const vec2f& v)
+    {
+        return vec2f(std::roundf(v.x), std::roundf(v.y));
+    }
+
+    inline vec2f vabs(vec2f v)
+    {
+        v.x = std::abs(v.x);
+        v.y = std::abs(v.y);
+        return v;
     }
 
 
@@ -147,13 +191,18 @@ namespace hxm
     private:
     protected:
     public:
-        // TODO: more operators
-        int32_t& operator[](uint32_t idx);
-        int32_t operator[](uint32_t idx) const;
         vec2i& operator+=(const vec2i& rhs);
+        vec2i& operator+=(const int32_t rhs);
         vec2i& operator-=(const vec2i& rhs);
+        vec2i& operator-=(const int32_t rhs);
+        vec2i& operator*=(const vec2i& rhs);
+        vec2i& operator*=(const int32_t rhs);
+        vec2i& operator/=(const vec2i& rhs);
+        vec2i& operator/=(const int32_t rhs);
         bool operator==(const vec2i& other) const;
         bool operator!=(const vec2i& rhs) const;
+        int32_t& operator[](uint32_t idx);
+        int32_t operator[](uint32_t idx) const;
 
         vec2i();
         vec2i(int32_t v);
@@ -168,17 +217,52 @@ namespace hxm
         return lhs;
     }
 
+    inline vec2i operator+(vec2i lhs, const int32_t rhs)
+    {
+        lhs += rhs;
+        return lhs;
+    }
+
     inline vec2i operator-(vec2i lhs, const vec2i& rhs)
     {
         lhs -= rhs;
         return lhs;
     }
 
-    inline vec2i clamp(vec2i v, int32_t min, int32_t max)
+    inline vec2i operator-(vec2i lhs, const int32_t rhs)
     {
-        v.x = std::max(std::min(v.x, max), min);
-        v.y = std::max(std::min(v.y, max), min);
-        return v;
+        lhs -= rhs;
+        return lhs;
+    }
+
+    // negation operator
+    inline vec2i operator-(vec2i rhs)
+    {
+        return vec2i(-rhs.x, -rhs.y);
+    }
+
+    inline vec2i operator*(vec2i lhs, const vec2i& rhs)
+    {
+        lhs *= rhs;
+        return lhs;
+    }
+
+    inline vec2i operator*(vec2i lhs, const int32_t rhs)
+    {
+        lhs *= rhs;
+        return lhs;
+    }
+
+    inline vec2i operator/(vec2i lhs, const vec2i& rhs)
+    {
+        lhs /= rhs;
+        return lhs;
+    }
+
+    inline vec2i operator/(vec2i lhs, const int32_t rhs)
+    {
+        lhs /= rhs;
+        return lhs;
     }
 
     inline vec2i clamp(vec2i v, const vec2i& vMin, const vec2i& vMax)
@@ -186,6 +270,43 @@ namespace hxm
         v.x = std::max(std::min(v.x, vMax.x), vMin.x);
         v.y = std::max(std::min(v.y, vMax.y), vMin.y);
         return v;
+    }
+
+    inline vec2i clamp(vec2i v, const int32_t vmin, const int32_t vmax)
+    {
+        v.x = std::max(std::min(v.x, vmax), vmin);
+        v.y = std::max(std::min(v.y, vmax), vmin);
+        return v;
+    }
+
+    inline vec2i vabs(vec2i v)
+    {
+        v.x = std::abs(v.x);
+        v.y = std::abs(v.y);
+        return v;
+    }
+
+    // handles negative values in vec a
+    inline vec2i mod(const vec2i& a, const vec2i& b)
+    {
+        vec2i result;
+        result.x = (a.x + ((abs(a.x / b.x) + 1) * b.x)) % b.x;
+        result.y = (a.y + ((abs(a.y / b.y) + 1) * b.y)) % b.y;
+        return result;
+    }
+
+    inline vec2i operator<<(vec2i lhs, const uint32_t rhs)
+    {
+        lhs.x <<= rhs;
+        lhs.y <<= rhs;
+        return lhs;
+    }
+
+    inline vec2i operator>>(vec2i lhs, const uint32_t rhs)
+    {
+        lhs.x >>= rhs;
+        lhs.y >>= rhs;
+        return lhs;
     }
 
 
@@ -205,22 +326,33 @@ namespace hxm
     private:
     protected:
     public:
-        // TODO: more operators
-        uint32_t& operator[](uint32_t idx);
-        uint32_t operator[](uint32_t idx) const;
         vec2u& operator+=(const vec2u& rhs);
+        vec2u& operator+=(const uint32_t rhs);
         vec2u& operator-=(const vec2u& rhs);
+        vec2u& operator-=(const uint32_t rhs);
+        vec2u& operator*=(const vec2u& rhs);
+        vec2u& operator*=(const uint32_t rhs);
+        vec2u& operator/=(const vec2u& rhs);
+        vec2u& operator/=(const uint32_t rhs);
         bool operator==(const vec2u& rhs) const;
         bool operator!=(const vec2u& rhs) const;
+        uint32_t& operator[](uint32_t idx);
+        uint32_t operator[](uint32_t idx) const;
 
         vec2u();
         vec2u(uint32_t v);
         vec2u(uint32_t x, uint32_t y);
-        vec2u(const vec2i& v);
-        vec2u(const vec2f& v);
+        vec2u(const vec2i& ivec);
+        vec2u(const vec2f& fvec);
     };
 
     inline vec2u operator+(vec2u lhs, const vec2u& rhs)
+    {
+        lhs += rhs;
+        return lhs;
+    }
+
+    inline vec2u operator+(vec2u lhs, const uint32_t rhs)
     {
         lhs += rhs;
         return lhs;
@@ -232,11 +364,62 @@ namespace hxm
         return lhs;
     }
 
+    inline vec2u operator-(vec2u lhs, const uint32_t rhs)
+    {
+        lhs -= rhs;
+        return lhs;
+    }
+
+    inline vec2u operator*(vec2u lhs, const vec2u& rhs)
+    {
+        lhs *= rhs;
+        return lhs;
+    }
+
+    inline vec2u operator*(vec2u lhs, const uint32_t rhs)
+    {
+        lhs *= rhs;
+        return lhs;
+    }
+
+    inline vec2u operator/(vec2u lhs, const vec2u& rhs)
+    {
+        lhs /= rhs;
+        return lhs;
+    }
+
+    inline vec2u operator/(vec2u lhs, const uint32_t rhs)
+    {
+        lhs /= rhs;
+        return lhs;
+    }
+
     inline vec2u clamp(vec2u v, const vec2u& vMin, const vec2u& vMax)
     {
         v.x = std::max(std::min(v.x, vMax.x), vMin.x);
         v.y = std::max(std::min(v.y, vMax.y), vMin.y);
         return v;
+    }
+
+    inline vec2u clamp(vec2u v, const uint32_t vMin, const uint32_t vMax)
+    {
+        v.x = std::max(std::min(v.x, vMax), vMin);
+        v.y = std::max(std::min(v.y, vMax), vMin);
+        return v;
+    }
+
+    inline vec2u operator<<(vec2u lhs, const uint32_t rhs)
+    {
+        lhs.x <<= rhs;
+        lhs.y <<= rhs;
+        return lhs;
+    }
+
+    inline vec2u operator>>(vec2u lhs, const uint32_t rhs)
+    {
+        lhs.x >>= rhs;
+        lhs.y >>= rhs;
+        return lhs;
     }
 
 
@@ -259,32 +442,42 @@ namespace hxm
     protected:
     public:
         vec3f& operator+=(const vec3f& rhs);
+        vec3f& operator+=(const float rhs);
         vec3f& operator-=(const vec3f& rhs);
+        vec3f& operator-=(const float rhs);
         vec3f& operator*=(const vec3f& rhs);
-        vec3f& operator*=(float rhs);
+        vec3f& operator*=(const float rhs);
         vec3f& operator/=(const vec3f& rhs);
-        vec3f& operator/=(float rhs);
-        float& operator[](uint32_t idx);
-        float  operator[](uint32_t idx) const;
+        vec3f& operator/=(const float rhs);
         bool   operator==(const vec3f& rhs) const;
         bool   operator!=(const vec3f& rhs) const;
+        float& operator[](uint32_t idx);
+        float  operator[](uint32_t idx) const;
 
+        // TODO move to utils file
         uint32_t minCompIdx() const;    // the index of the smallest component of this vector
+        
         float dot(const vec3f& rhs) const;
         float length() const;
-        vec3f& normalize();
+        float normalize(); // returns the length before normalization
 
         vec3f();
         vec3f(float v);
         vec3f(float x, float y, float z);
         vec3f(const vec2f&, float z);
-        vec3f(const vec3u& v);
-        vec3f(const vec3i& v);
-        vec3f(const vec4f& v);
-        vec3f(const vec4u& v);
+        vec3f(const vec3u& uvec);
+        vec3f(const vec3i& ivec);
+        vec3f(const vec4f& fvec4);
+        vec3f(const vec4u& uvec4);
     };
 
     inline vec3f operator+(vec3f lhs, const vec3f& rhs)
+    {
+        lhs += rhs;
+        return lhs;
+    }
+
+    inline vec3f operator+(vec3f lhs, const float rhs)
     {
         lhs += rhs;
         return lhs;
@@ -296,6 +489,13 @@ namespace hxm
         return lhs;
     }
 
+    inline vec3f operator-(vec3f lhs, const float rhs)
+    {
+        lhs -= rhs;
+        return lhs;
+    }
+
+    // negation operator
     inline vec3f operator-(const vec3f& rhs)
     {
         return vec3f(-rhs.x, -rhs.y, -rhs.z);
@@ -307,19 +507,7 @@ namespace hxm
         return lhs;
     }
 
-    inline vec3f operator+(vec3f lhs, float rhs)
-    {
-        lhs += rhs;
-        return lhs;
-    }
-
-    inline vec3f operator-(vec3f lhs, float rhs)
-    {
-        lhs -= rhs;
-        return lhs;
-    }
-
-    inline vec3f operator*(vec3f lhs, float rhs)
+    inline vec3f operator*(vec3f lhs, const float rhs)
     {
         lhs *= rhs;
         return lhs;
@@ -331,7 +519,7 @@ namespace hxm
         return lhs;
     }
 
-    inline vec3f operator/(vec3f lhs, float rhs)
+    inline vec3f operator/(vec3f lhs, const float rhs)
     {
         lhs /= rhs;
         return lhs;
@@ -356,8 +544,16 @@ namespace hxm
         result /= v.length();
         return result;
     }
+    
+    inline vec3f clamp(vec3f v, const vec3f& vmin, const vec3f& vmax)
+    {
+        v.x = std::max(std::min(v.x, vmax.x), vmin.x);
+        v.y = std::max(std::min(v.y, vmax.y), vmin.y);
+        v.z = std::max(std::min(v.z, vmax.z), vmin.z);
+        return v;
+    }
 
-    inline vec3f clamp(vec3f v, float vmin, float vmax)
+    inline vec3f clamp(vec3f v, const float vmin, const float vmax)
     {
         v.x = std::max(std::min(v.x, vmax), vmin);
         v.y = std::max(std::min(v.y, vmax), vmin);
@@ -365,11 +561,16 @@ namespace hxm
         return v;
     }
 
-    inline vec3f clamp(vec3f v, vec3f vmin, vec3f vmax)
+    inline vec3f round(const vec3f& v)
     {
-        v.x = std::max(std::min(v.x, vmax.x), vmin.x);
-        v.y = std::max(std::min(v.y, vmax.y), vmin.y);
-        v.z = std::max(std::min(v.z, vmax.z), vmin.z);
+        return vec3f(std::roundf(v.x), std::roundf(v.y), std::roundf(v.z));
+    }
+
+    inline vec3f vabs(vec3f v)
+    {
+        v.x = std::abs(v.x);
+        v.y = std::abs(v.y);
+        v.z = std::abs(v.z);
         return v;
     }
 
@@ -390,13 +591,18 @@ namespace hxm
     private:
     protected:
     public:
-        // TODO: more operators
+        vec3i& operator+=(const vec3i& rhs);
+        vec3i& operator+=(const int32_t rhs);
+        vec3i& operator-=(const vec3i& rhs);
+        vec3i& operator-=(const int32_t rhs);
+        vec3i& operator*=(const vec3i& rhs);
+        vec3i& operator*=(const int32_t rhs);
+        vec3i& operator/=(const vec3i& rhs);
+        vec3i& operator/=(const int32_t rhs);
+        bool operator==(const vec3i& rhs) const;
+        bool operator!=(const vec3i& rhs) const;
         int32_t& operator[](uint32_t idx);
         int32_t operator[](uint32_t idx) const;
-        vec3i& operator+=(const vec3i& rhs);
-        vec3i& operator-=(const vec3i& rhs);
-        bool operator==(const vec3i& other) const;
-        bool operator!=(const vec3i& rhs) const;
 
         vec3i();
         vec3i(int32_t v);
@@ -411,18 +617,52 @@ namespace hxm
         return lhs;
     }
 
+    inline vec3i operator+(vec3i lhs, const float rhs)
+    {
+        lhs += rhs;
+        return lhs;
+    }
+
     inline vec3i operator-(vec3i lhs, const vec3i& rhs)
     {
         lhs -= rhs;
         return lhs;
     }
 
-    inline vec3i clamp(vec3i v, int32_t min, int32_t max)
+    inline vec3i operator-(vec3i lhs, const float rhs)
     {
-        v.x = std::max(std::min(v.x, max), min);
-        v.y = std::max(std::min(v.y, max), min);
-        v.z = std::max(std::min(v.z, max), min);
-        return v;
+        lhs -= rhs;
+        return lhs;
+    }
+
+    // negation operator
+    inline vec3i operator-(const vec3i& rhs)
+    {
+        return vec3i(-rhs.x, -rhs.y, -rhs.z);
+    }
+
+    inline vec3i operator*(vec3i lhs, const vec3i& rhs)
+    {
+        lhs *= rhs;
+        return lhs;
+    }
+
+    inline vec3i operator*(vec3i lhs, const int32_t rhs)
+    {
+        lhs *= rhs;
+        return lhs;
+    }
+
+    inline vec3i operator/(vec3i lhs, const vec3i& rhs)
+    {
+        lhs /= rhs;
+        return lhs;
+    }
+
+    inline vec3i operator/(vec3i lhs, const int32_t rhs)
+    {
+        lhs /= rhs;
+        return lhs;
     }
 
     inline vec3i clamp(vec3i v, const vec3i& vMin, const vec3i& vMax)
@@ -431,6 +671,48 @@ namespace hxm
         v.y = std::max(std::min(v.y, vMax.y), vMin.y);
         v.z = std::max(std::min(v.z, vMax.z), vMin.z);
         return v;
+    }
+
+    inline vec3i clamp(vec3i v, const int32_t vmin, const int32_t vmax)
+    {
+        v.x = std::max(std::min(v.x, vmax), vmin);
+        v.y = std::max(std::min(v.y, vmax), vmin);
+        v.z = std::max(std::min(v.z, vmax), vmin);
+        return v;
+    }
+
+    inline vec3i vabs(vec3i v)
+    {
+        v.x = std::abs(v.x);
+        v.y = std::abs(v.y);
+        v.z = std::abs(v.z);
+        return v;
+    }
+
+    // handles negative values in vec a
+    inline vec3i mod(const vec3i& a, const vec3i& b)
+    {
+        vec3i result;
+        result.x = (a.x + ((std::abs(a.x / b.x) + 1) * b.x)) % b.x;
+        result.y = (a.y + ((std::abs(a.y / b.y) + 1) * b.y)) % b.y;
+        result.z = (a.z + ((std::abs(a.z / b.z) + 1) * b.z)) % b.z;
+        return result;
+    }
+
+    inline vec3i operator<<(vec3i lhs, const uint32_t rhs)
+    {
+        lhs.x <<= rhs;
+        lhs.y <<= rhs;
+        lhs.z <<= rhs;
+        return lhs;
+    }
+
+    inline vec3i operator>>(vec3i lhs, const uint32_t rhs)
+    {
+        lhs.x >>= rhs;
+        lhs.y >>= rhs;
+        lhs.z >>= rhs;
+        return lhs;
     }
 
 
@@ -451,18 +733,24 @@ namespace hxm
     private:
     protected:
     public:
-        // TODO: more operators
-        uint32_t& operator[](uint32_t idx);
-        uint32_t operator[](uint32_t idx) const;
-        //bool operator==(const vec3u& rhs);
+        vec3u& operator+=(const vec3u& rhs);
+        vec3u& operator+=(const uint32_t rhs);
+        vec3u& operator-=(const vec3u& rhs);
+        vec3u& operator-=(const uint32_t rhs);
+        vec3u& operator*=(const vec3u& rhs);
+        vec3u& operator*=(const uint32_t rhs);
+        vec3u& operator/=(const vec3u& rhs);
+        vec3u& operator/=(const uint32_t rhs);
         bool operator==(const vec3u& rhs) const;
         bool operator!=(const vec3u& rhs) const;
+        uint32_t& operator[](uint32_t idx);
+        uint32_t operator[](uint32_t idx) const;
 
         vec3u();
         vec3u(uint32_t v);
         vec3u(uint32_t x, uint32_t y, uint32_t z);
-        vec3u(const vec3f& v);
-        vec3u(const vec3i& v);
+        vec3u(const vec3f& fvec);
+        vec3u(const vec3i& ivec);
     };
 
 
@@ -483,21 +771,90 @@ namespace hxm
     private:
     protected:
     public:
-        // TODO: more operators
-        uint8_t& operator[](uint32_t idx);
-        uint8_t operator[](uint32_t idx) const;
-        //bool operator==(const vec3u& rhs);
+        vec3u8& operator+=(const vec3u8& rhs);
+        vec3u8& operator+=(const uint8_t rhs);
+        vec3u8& operator-=(const vec3u8& rhs);
+        vec3u8& operator-=(const uint8_t rhs);
+        vec3u8& operator*=(const vec3u8& rhs);
+        vec3u8& operator*=(const uint8_t rhs);
+        vec3u8& operator/=(const vec3u8& rhs);
+        vec3u8& operator/=(const uint8_t rhs);
         bool operator==(const vec3u8& rhs) const;
         bool operator!=(const vec3u8& rhs) const;
+        uint8_t& operator[](uint32_t idx);
+        uint8_t operator[](uint32_t idx) const;
 
         vec3u8();
         vec3u8(uint8_t v);
         vec3u8(uint8_t x, uint8_t y, uint8_t z);
-        vec3u8(const vec3f& v);
-        vec3u8(const vec3i& v);
-        vec3u8(const vec3u& v);
+        vec3u8(const vec3f& fvec);
+        vec3u8(const vec3i& ivec);
+        vec3u8(const vec3u& uvec32);
     };
 
+    inline vec3u8 operator+(vec3u8 lhs, const vec3u8& rhs)
+    {
+        lhs += rhs;
+        return lhs;
+    }
+
+    inline vec3u8 operator+(vec3u8 lhs, const uint8_t rhs)
+    {
+        lhs += rhs;
+        return lhs;
+    }
+
+    inline vec3u8 operator-(vec3u8 lhs, const vec3u8& rhs)
+    {
+        lhs -= rhs;
+        return lhs;
+    }
+
+    inline vec3u8 operator-(vec3u8 lhs, const uint8_t rhs)
+    {
+        lhs -= rhs;
+        return lhs;
+    }
+
+    inline vec3u8 operator*(vec3u8 lhs, const vec3u8& rhs)
+    {
+        lhs *= rhs;
+        return lhs;
+    }
+
+    inline vec3u8 operator*(vec3u8 lhs, const uint8_t rhs)
+    {
+        lhs *= rhs;
+        return lhs;
+    }
+
+    inline vec3u8 operator/(vec3u8 lhs, const vec3u8& rhs)
+    {
+        lhs /= rhs;
+        return lhs;
+    }
+
+    inline vec3u8 operator/(vec3u8 lhs, const uint8_t rhs)
+    {
+        lhs /= rhs;
+        return lhs;
+    }
+
+    inline vec3u8 clamp(vec3u8 v, const vec3u8& vMin, const vec3u8& vMax)
+    {
+        v.x = std::max(std::min(v.x, vMax.x), vMin.x);
+        v.y = std::max(std::min(v.y, vMax.y), vMin.y);
+        v.z = std::max(std::min(v.z, vMax.z), vMin.z);
+        return v;
+    }
+
+    inline vec3u8 clamp(vec3u8 v, const uint8_t vmin, const uint8_t vmax)
+    {
+        v.x = std::max(std::min(v.x, vmax), vmin);
+        v.y = std::max(std::min(v.y, vmax), vmin);
+        v.z = std::max(std::min(v.z, vmax), vmin);
+        return v;
+    }
 
     // VEC4F ------------------------------------------------------------------
     class vec4f {
@@ -517,31 +874,35 @@ namespace hxm
     protected:
     public:
         vec4f& operator+=(const vec4f& rhs);
+        vec4f& operator+=(const float rhs);
         vec4f& operator-=(const vec4f& rhs);
+        vec4f& operator-=(const float rhs);
         vec4f& operator*=(const vec4f& rhs);
-        vec4f& operator*=(float rhs);
+        vec4f& operator*=(const float rhs);
         vec4f& operator/=(const vec4f& rhs);
-        vec4f& operator/=(float rhs);
-        bool operator==(const vec4f& other) const;
-        bool operator!=(const vec4f& other) const;
+        vec4f& operator/=(const float rhs);
+        bool operator==(const vec4f& rhs) const;
+        bool operator!=(const vec4f& rhs) const;
         float& operator[](uint32_t idx);
         float operator[](uint32_t idx) const;
 
+        // TODO jjensen: remove copy and set
         vec4f& copy(const vec4f& v);
         vec4f& set(float x, float y, float z, float w);
+
         uint32_t minCompIdx() const;    // the index of the smallest component of this vector
         float dot(const vec4f& rhs) const;
         float length() const;
-        vec4f& normalize();
+        float normalize();  // returns length before normalization
 
         vec4f();
         vec4f(float v);
         vec4f(float x, float y, float z, float w);
-        vec4f(const vec3f& vec);
-        vec4f(const vec3f& vec, float w);
-        vec4f(const vec4u& vec);
-        vec4f(const vec4i& vec);
-        vec4f(const vec5f& vec);
+        vec4f(const vec3f& fvec3);
+        vec4f(const vec3f& fvec3, float w);
+        vec4f(const vec4u& uvec);
+        vec4f(const vec4i& ivec);
+        vec4f(const vec5f& fvec5);
     };
 
     inline vec4f operator+(vec4f lhs, const vec4f& rhs)
@@ -550,7 +911,7 @@ namespace hxm
         return lhs;
     }
 
-    inline vec4f operator+(vec4f lhs, float rhs)
+    inline vec4f operator+(vec4f lhs, const float rhs)
     {
         lhs += rhs;
         return lhs;
@@ -562,15 +923,16 @@ namespace hxm
         return lhs;
     }
 
-    inline vec4f operator-(const vec4f& lhs)
-    {
-        return vec4f(-lhs.x, -lhs.y, -lhs.z, -lhs.w);
-    }
-
-    inline vec4f operator-(vec4f lhs, float rhs)
+    inline vec4f operator-(vec4f lhs, const float rhs)
     {
         lhs -= rhs;
         return lhs;
+    }
+
+    // negation operator
+    inline vec4f operator-(const vec4f& lhs)
+    {
+        return vec4f(-lhs.x, -lhs.y, -lhs.z, -lhs.w);
     }
 
     inline vec4f operator*(vec4f lhs, const vec4f& rhs)
@@ -579,7 +941,7 @@ namespace hxm
         return lhs;
     }
 
-    inline vec4f operator*(vec4f lhs, float rhs)
+    inline vec4f operator*(vec4f lhs, const float rhs)
     {
         lhs *= rhs;
         return lhs;
@@ -591,7 +953,7 @@ namespace hxm
         return lhs;
     }
 
-    inline vec4f operator/(vec4f lhs, float rhs)
+    inline vec4f operator/(vec4f lhs, const float rhs)
     {
         lhs /= rhs;
         return lhs;
@@ -618,27 +980,19 @@ namespace hxm
         return result;
     }
 
-    inline vec4f round(const vec4f& v)
-    {
-        vec4f result = { std::roundf(v.x), std::roundf(v.y), std::roundf(v.z), std::roundf(v.w) };
-        return result;
-    }
-
     inline float dot(const vec4f& a, const vec4f& b)
     {
         return (a.x * b.x) + (a.y * b.y) + (a.z * b.z) + (a.w * b.w);
     }
 
-    inline vec4f clamp(vec4f v, float vmin, float vmax)
+    inline vec4f normalize(const vec4f& v)
     {
-        v.x = std::max(std::min(v.x, vmax), vmin);
-        v.y = std::max(std::min(v.y, vmax), vmin);
-        v.z = std::max(std::min(v.z, vmax), vmin);
-        v.w = std::max(std::min(v.w, vmax), vmin);
-        return v;
+        vec4f result = v;
+        result /= v.length();
+        return result;
     }
-
-    inline vec4f clamp(vec4f v, vec4f vmin, vec4f vmax)
+    
+    inline vec4f clamp(vec4f v, const vec4f& vmin, const vec4f& vmax)
     {
         v.x = std::max(std::min(v.x, vmax.x), vmin.x);
         v.y = std::max(std::min(v.y, vmax.y), vmin.y);
@@ -647,11 +1001,27 @@ namespace hxm
         return v;
     }
 
-    inline vec4f normalize(const vec4f& v)
+    inline vec4f clamp(vec4f v, const float vmin, const float vmax)
     {
-        vec4f result = v;
-        result /= v.length();
-        return result;
+        v.x = std::max(std::min(v.x, vmax), vmin);
+        v.y = std::max(std::min(v.y, vmax), vmin);
+        v.z = std::max(std::min(v.z, vmax), vmin);
+        v.w = std::max(std::min(v.w, vmax), vmin);
+        return v;
+    }
+
+    inline vec4f round(const vec4f& v)
+    {
+        return vec4f(std::roundf(v.x), std::roundf(v.y), std::roundf(v.z), std::roundf(v.w));
+    }
+
+    inline vec4f vabs(vec4f v)
+    {
+        v.x = std::abs(v.x);
+        v.y = std::abs(v.y);
+        v.z = std::abs(v.z);
+        v.w = std::abs(v.w);
+        return v;
     }
 
 
@@ -672,16 +1042,19 @@ namespace hxm
     private:
     protected:
     public:
-        // TODO: more operators
+        vec4i& operator+=(const vec4i& rhs);
+        vec4i& operator+=(const int32_t rhs);
+        vec4i& operator-=(const vec4i& rhs);
+        vec4i& operator-=(const int32_t rhs);
+        vec4i& operator*=(const vec4i& rhs);
+        vec4i& operator*=(const int32_t rhs);
+        vec4i& operator/=(const vec4i& rhs);
+        vec4i& operator/=(const int32_t rhs);
+        bool operator==(const vec4i& rhs) const;
+        bool operator==(const vec4u& rhs) const;    // vec4i == vec4u
+        bool operator!=(const vec4i& rhs) const;
         int32_t& operator[](uint32_t idx);
         int32_t operator[](uint32_t idx) const;
-        vec4i& operator+=(const vec4i& rhs);
-        vec4i& operator-=(const vec4i& rhs);
-        vec4i& operator*=(const vec4i& rhs);
-        vec4i& operator+=(int value);
-        bool operator==(const vec4i& other) const;
-        bool operator!=(const vec4i& other) const;
-        bool operator==(const vec4u& other) const;    // vec4i == vec4u
 
         vec4i();
         vec4i(int32_t v);
@@ -690,13 +1063,13 @@ namespace hxm
         vec4i(const vec4u& uvec);
     };
 
-    inline vec4i operator+(vec4i lhs, size_t rhs)
+    inline vec4i operator+(vec4i lhs, const vec4i& rhs)
     {
         lhs += rhs;
         return lhs;
     }
 
-    inline vec4i operator+(vec4i lhs, const vec4i& rhs)
+    inline vec4i operator+(vec4i lhs, const int32_t rhs)
     {
         lhs += rhs;
         return lhs;
@@ -708,9 +1081,39 @@ namespace hxm
         return lhs;
     }
 
+    inline vec4i operator-(vec4i lhs, const int32_t rhs)
+    {
+        lhs -= rhs;
+        return lhs;
+    }
+
+    // negation operator
+    inline vec4i operator-(const vec4i& lhs)
+    {
+        return vec4i(-lhs.x, -lhs.y, -lhs.z, -lhs.w);
+    }
+
     inline vec4i operator*(vec4i lhs, const vec4i& rhs)
     {
         lhs *= rhs;
+        return lhs;
+    }
+
+    inline vec4i operator*(vec4i lhs, const int32_t rhs)
+    {
+        lhs *= rhs;
+        return lhs;
+    }
+
+    inline vec4i operator/(vec4i lhs, const vec4i& rhs)
+    {
+        lhs /= rhs;
+        return lhs;
+    }
+
+    inline vec4i operator/(vec4i lhs, const int32_t rhs)
+    {
+        lhs /= rhs;
         return lhs;
     }
 
@@ -723,7 +1126,16 @@ namespace hxm
         return v;
     }
 
-    inline vec4i vecAbs(vec4i v)
+    inline vec4i clamp(vec4i v, const int32_t vmin, const int32_t vmax)
+    {
+        v.x = std::max(std::min(v.x, vmax), vmin);
+        v.y = std::max(std::min(v.y, vmax), vmin);
+        v.z = std::max(std::min(v.z, vmax), vmin);
+        v.w = std::max(std::min(v.w, vmax), vmin);
+        return v;
+    }
+
+    inline vec4i vabs(vec4i v)
     {
         v.x = std::abs(v.x);
         v.y = std::abs(v.y);
@@ -757,6 +1169,24 @@ namespace hxm
         return result;
     }
 
+    inline vec4i operator<<(vec4i lhs, const uint32_t rhs)
+    {
+        lhs.x <<= rhs;
+        lhs.y <<= rhs;
+        lhs.z <<= rhs;
+        lhs.w <<= rhs;
+        return lhs;
+    }
+
+    inline vec4i operator>>(vec4i lhs, const uint32_t rhs)
+    {
+        lhs.x >>= rhs;
+        lhs.y >>= rhs;
+        lhs.z >>= rhs;
+        lhs.w >>= rhs;
+        return lhs;
+    }
+
 
     // VEC4U ------------------------------------------------------------------
     class vec4u {
@@ -775,45 +1205,35 @@ namespace hxm
     private:
     protected:
     public:
-        // TODO: more operators
+        vec4u& operator+=(const vec4u& rhs);
+        vec4u& operator+=(const uint32_t rhs);
+        vec4u& operator-=(const vec4u& rhs);
+        vec4u& operator-=(const uint32_t rhs);
+        vec4u& operator*=(const vec4u& rhs);
+        vec4u& operator*=(const uint32_t rhs);
+        vec4u& operator/=(const vec4u& rhs);
+        vec4u& operator/=(const uint32_t rhs);
+        vec4u& operator%=(const uint32_t rhs);
+        bool operator==(const vec4u& rhs) const;
+        bool operator==(const vec4i& rhs) const;    // vec4u == vec4i
+        bool operator!=(const vec4u& rhs) const;
         uint32_t& operator[](uint32_t idx);
         uint32_t operator[](uint32_t idx) const;
-        bool operator==(const vec4u& other) const;
-        bool operator==(const vec4i& other) const;    // vec4u == vec4i
-        bool operator!=(const vec4u& other) const;
-        vec4u& operator/=(size_t value);
-        vec4u& operator%=(size_t value);
-        vec4u& operator+=(size_t rhs);
-        vec4u& operator+=(const vec4u& other);
-        vec4u& operator-=(const vec4u& rhs);
-        vec4u& operator-=(const int& rhs);
 
         vec4u();
         vec4u(uint32_t v);
         vec4u(uint32_t x, uint32_t y, uint32_t z, uint32_t w);
-        vec4u(const vec4f& v);
-        vec4u(const vec4i& v);
+        vec4u(const vec4f& fvec);
+        vec4u(const vec4i& ivec);
     };
 
-    inline vec4u operator/(vec4u lhs, size_t rhs)
-    {
-        lhs /= rhs;
-        return lhs;
-    }
-
-    inline vec4u operator%(vec4u lhs, size_t rhs)
-    {
-        lhs %= rhs;
-        return lhs;
-    }
-
-    inline vec4u operator+(vec4u lhs, size_t rhs)
+    inline vec4u operator+(vec4u lhs, const vec4u& rhs)
     {
         lhs += rhs;
         return lhs;
     }
 
-    inline vec4u operator+(vec4u lhs, const vec4u& rhs)
+    inline vec4u operator+(vec4u lhs, const uint32_t rhs)
     {
         lhs += rhs;
         return lhs;
@@ -825,30 +1245,39 @@ namespace hxm
         return lhs;
     }
 
-    inline vec4u operator<<(vec4u lhs, size_t rhs)
+    inline vec4u operator-(vec4u lhs, const uint32_t rhs)
     {
-        lhs.x <<= rhs;
-        lhs.y <<= rhs;
-        lhs.z <<= rhs;
-        lhs.w <<= rhs;
+        lhs -= rhs;
         return lhs;
     }
 
-    inline vec4u operator>>(vec4u lhs, size_t rhs)
+    inline vec4u operator*(vec4u lhs, const vec4u& rhs)
     {
-        lhs.x >>= rhs;
-        lhs.y >>= rhs;
-        lhs.z >>= rhs;
-        lhs.w >>= rhs;
+        lhs *= rhs;
         return lhs;
     }
 
-    inline vec4u operator*(vec4u lhs, size_t rhs)
+    inline vec4u operator*(vec4u lhs, const uint32_t rhs)
     {
-        lhs.x *= rhs;
-        lhs.y *= rhs;
-        lhs.z *= rhs;
-        lhs.w *= rhs;
+        lhs *= rhs;
+        return lhs;
+    }
+
+    inline vec4u operator/(vec4u lhs, const vec4u& rhs)
+    {
+        lhs /= rhs;
+        return lhs;
+    }
+
+    inline vec4u operator/(vec4u lhs, const uint32_t rhs)
+    {
+        lhs /= rhs;
+        return lhs;
+    }
+
+    inline vec4u operator%(vec4u lhs, const uint32_t rhs)
+    {
+        lhs %= rhs;
         return lhs;
     }
 
@@ -859,6 +1288,33 @@ namespace hxm
         v.z = std::max(std::min(v.z, vMax.z), vMin.z);
         v.w = std::max(std::min(v.w, vMax.w), vMin.w);
         return v;
+    }
+
+    inline vec4u clamp(vec4u v, const uint32_t vMin, const uint32_t vMax)
+    {
+        v.x = std::max(std::min(v.x, vMax), vMin);
+        v.y = std::max(std::min(v.y, vMax), vMin);
+        v.z = std::max(std::min(v.z, vMax), vMin);
+        v.w = std::max(std::min(v.w, vMax), vMin);
+        return v;
+    }
+
+    inline vec4u operator<<(vec4u lhs, const uint32_t rhs)
+    {
+        lhs.x <<= rhs;
+        lhs.y <<= rhs;
+        lhs.z <<= rhs;
+        lhs.w <<= rhs;
+        return lhs;
+    }
+
+    inline vec4u operator>>(vec4u lhs, const uint32_t rhs)
+    {
+        lhs.x >>= rhs;
+        lhs.y >>= rhs;
+        lhs.z >>= rhs;
+        lhs.w >>= rhs;
+        return lhs;
     }
 
     // TODO: move to a utils file?
@@ -890,33 +1346,35 @@ namespace hxm
     private:
     protected:
     public:
-        // TODO: more operators
+        vec4u8& operator+=(const vec4u8& rhs);
+        vec4u8& operator+=(const uint8_t rhs);
+        vec4u8& operator-=(const vec4u8& rhs);
+        vec4u8& operator-=(const uint8_t rhs);
+        vec4u8& operator*=(const vec4u8& rhs);
+        vec4u8& operator*=(const uint8_t rhs);
+        vec4u8& operator/=(const vec4u8& rhs);
+        vec4u8& operator/=(const uint8_t rhs);
+        vec4u8& operator%=(const uint8_t rhs);
+        bool operator==(const vec4u8& rhs) const;
+        bool operator!=(const vec4u8& rhs) const;
         uint8_t& operator[](uint32_t idx);
         uint8_t operator[](uint32_t idx) const;
-        bool operator==(const vec4u8& other) const;
-        bool operator!=(const vec4u8& other) const;
-        //vec4u8& operator/=(size_t value);
-        //vec4u8& operator%=(size_t value);
-        vec4u8& operator+=(size_t rhs);
-        vec4u8& operator+=(const vec4u8& other);
-        vec4u8& operator-=(const vec4u8& rhs);
-        vec4u8& operator-=(const int& rhs);
 
         vec4u8();
         vec4u8(uint8_t v);
         vec4u8(uint8_t x, uint8_t y, uint8_t z, uint8_t w);
-        vec4u8(const vec4f& v);
-        vec4u8(const vec4i& v);
-        vec4u8(const vec4u& v);
+        vec4u8(const vec4f& fvec);
+        vec4u8(const vec4i& ivec);
+        vec4u8(const vec4u& uvec32);
     };
 
-    inline vec4u8 operator+(vec4u8 lhs, uint8_t rhs)
+    inline vec4u8 operator+(vec4u8 lhs, const vec4u8& rhs)
     {
         lhs += rhs;
         return lhs;
     }
 
-    inline vec4u8 operator+(vec4u8 lhs, const vec4u8& rhs)
+    inline vec4u8 operator+(vec4u8 lhs, const uint8_t rhs)
     {
         lhs += rhs;
         return lhs;
@@ -928,12 +1386,51 @@ namespace hxm
         return lhs;
     }
 
+    inline vec4u8 operator-(vec4u8 lhs, const uint8_t rhs)
+    {
+        lhs -= rhs;
+        return lhs;
+    }
+
+    inline vec4u8 operator*(vec4u8 lhs, const vec4u8& rhs)
+    {
+        lhs *= rhs;
+        return lhs;
+    }
+
+    inline vec4u8 operator*(vec4u8 lhs, const uint8_t rhs)
+    {
+        lhs *= rhs;
+        return lhs;
+    }
+
+    inline vec4u8 operator/(vec4u8 lhs, const vec4u8& rhs)
+    {
+        lhs /= rhs;
+        return lhs;
+    }
+
+    inline vec4u8 operator/(vec4u8 lhs, const uint8_t rhs)
+    {
+        lhs /= rhs;
+        return lhs;
+    }
+
     inline vec4u8 clamp(vec4u8 v, const vec4u8& vMin, const vec4u8& vMax)
     {
         v.x = std::max(std::min(v.x, vMax.x), vMin.x);
         v.y = std::max(std::min(v.y, vMax.y), vMin.y);
         v.z = std::max(std::min(v.z, vMax.z), vMin.z);
         v.w = std::max(std::min(v.w, vMax.w), vMin.w);
+        return v;
+    }
+
+    inline vec4u8 clamp(vec4u8 v, const uint8_t vmin, const uint8_t vmax)
+    {
+        v.x = std::max(std::min(v.x, vmax), vmin);
+        v.y = std::max(std::min(v.y, vmax), vmin);
+        v.z = std::max(std::min(v.z, vmax), vmin);
+        v.w = std::max(std::min(v.w, vmax), vmin);
         return v;
     }
 
@@ -955,34 +1452,36 @@ namespace hxm
     protected:
     public:
         vec5f& operator+=(const vec5f& rhs);
-        vec5f& operator+=(float rhs);
+        vec5f& operator+=(const float rhs);
         vec5f& operator-=(const vec5f& rhs);
-        vec5f& operator-=(float rhs);
+        vec5f& operator-=(const float rhs);
         vec5f& operator*=(const vec5f& rhs);
-        vec5f& operator*=(float rhs);
+        vec5f& operator*=(const float rhs);
         vec5f& operator/=(const vec5f& rhs);
-        vec5f& operator/=(float rhs);
+        vec5f& operator/=(const float rhs);
         bool operator==(const vec5f& other) const;
         bool operator!=(const vec5f& other) const;
         float& operator[](uint32_t idx);
         float operator[](uint32_t idx) const;
 
+        // TODO jjensen: remove copy and set
         vec5f& copy(const vec5f& v);
         vec5f& set(float x, float y, float z, float w, float v);
+
         uint32_t minCompIdx() const;    // the index of the smallest component of this vector
         float dot(const vec5f& rhs) const;
         float length() const;
-        vec5f& normalize();
+        float normalize();  // returns length before normalization
 
         vec5f();
         vec5f(float v);
         vec5f(float x, float y, float z, float w, float v);
-        vec5f(const vec3f& vec);
-        vec5f(const vec3f& vec, float w, float v);
-        vec5f(const vec4f& vec, float v);
-        vec5f(const vec4u& vec);
-        vec5f(const vec4i& vec);
-        vec5f(const vec5i& vec);
+        vec5f(const vec3f& fvec3);
+        vec5f(const vec3f& fvec3, float w, float v);
+        vec5f(const vec4f& fvec4, float v);
+        vec5f(const vec4u& uvec4);
+        vec5f(const vec4i& ivec4);
+        vec5f(const vec5i& ivec5);
     };
 
     inline vec5f operator+(vec5f lhs, const vec5f& rhs)
@@ -991,7 +1490,7 @@ namespace hxm
         return lhs;
     }
 
-    inline vec5f operator+(vec5f lhs, float rhs)
+    inline vec5f operator+(vec5f lhs, const float rhs)
     {
         lhs += rhs;
         return lhs;
@@ -1003,6 +1502,13 @@ namespace hxm
         return lhs;
     }
 
+    inline vec5f operator-(vec5f lhs, const float rhs)
+    {
+        lhs -= rhs;
+        return lhs;
+    }
+
+    // negation operator
     inline vec5f operator-(const vec5f& lhs)
     {
         return vec5f(-lhs.x, -lhs.y, -lhs.z, -lhs.w, -lhs.v);
@@ -1014,7 +1520,7 @@ namespace hxm
         return lhs;
     }
 
-    inline vec5f operator*(vec5f lhs, float rhs)
+    inline vec5f operator*(vec5f lhs, const float rhs)
     {
         lhs *= rhs;
         return lhs;
@@ -1026,16 +1532,57 @@ namespace hxm
         return lhs;
     }
 
-    inline vec5f operator/(vec5f lhs, float rhs)
+    inline vec5f operator/(vec5f lhs, const float rhs)
     {
         lhs /= rhs;
         return lhs;
     }
 
+    inline float dot(const vec5f& a, const vec5f& b)
+    {
+        return (a.x * b.x) + (a.y * b.y) + (a.z * b.z) + (a.w * b.w) + (a.v * b.v);
+    }
+
+    inline vec5f clamp(vec5f v, const vec5f& vmin, const vec5f& vmax)
+    {
+        v.x = std::max(std::min(v.x, vmax.x), vmin.x);
+        v.y = std::max(std::min(v.y, vmax.y), vmin.y);
+        v.z = std::max(std::min(v.z, vmax.z), vmin.z);
+        v.w = std::max(std::min(v.w, vmax.w), vmin.w);
+        v.v = std::max(std::min(v.v, vmax.v), vmin.v);
+        return v;
+    }
+
+    inline vec5f clamp(vec5f v, const float vmin, const float vmax)
+    {
+        v.x = std::max(std::min(v.x, vmax), vmin);
+        v.y = std::max(std::min(v.y, vmax), vmin);
+        v.z = std::max(std::min(v.z, vmax), vmin);
+        v.w = std::max(std::min(v.w, vmax), vmin);
+        v.v = std::max(std::min(v.v, vmax), vmin);
+        return v;
+    }
+
+    inline vec5f normalize(const vec5f& v)
+    {
+        vec5f result = v;
+        result /= v.length();
+        return result;
+    }
+
     inline vec5f round(const vec5f& v)
     {
-        vec5f result = { std::roundf(v.x), std::roundf(v.y), std::roundf(v.z), std::roundf(v.w), std::roundf(v.v) };
-        return result;
+        return vec5f(std::round(v.x), std::round(v.y), std::round(v.z), std::round(v.w), std::round(v.v));
+    }
+
+    inline vec5f vabs(vec5f v)
+    {
+        v.x = std::abs(v.x);
+        v.y = std::abs(v.y);
+        v.z = std::abs(v.z);
+        v.w = std::abs(v.w);
+        v.v = std::abs(v.v);
+        return v;
     }
 
 
@@ -1055,26 +1602,31 @@ namespace hxm
     private:
     protected:
     public:
-        int32_t& operator[](uint32_t idx);
-        int32_t operator[](uint32_t idx) const;
         vec5i& operator+=(const vec5i& rhs);
+        vec5i& operator+=(const int32_t rhs);
         vec5i& operator-=(const vec5i& rhs);
-        vec5i& operator+=(int value);
+        vec5i& operator-=(const int32_t rhs);
+        vec5i& operator*=(const vec5i& rhs);
+        vec5i& operator*=(const int32_t rhs);
+        vec5i& operator/=(const vec5i& rhs);
+        vec5i& operator/=(const int32_t rhs);
         bool operator==(const vec5i& other) const;
         bool operator!=(const vec5i& other) const;
+        int32_t& operator[](uint32_t idx);
+        int32_t operator[](uint32_t idx) const;
 
         vec5i();
         vec5i(int32_t v);
         vec5i(int32_t x, int32_t y, int32_t z, int32_t w, int32_t v);
     };
 
-    inline vec5i operator+(vec5i lhs, size_t rhs)
+    inline vec5i operator+(vec5i lhs, const vec5i& rhs)
     {
         lhs += rhs;
         return lhs;
     }
 
-    inline vec5i operator+(vec5i lhs, const vec5i& rhs)
+    inline vec5i operator+(vec5i lhs, const int32_t rhs)
     {
         lhs += rhs;
         return lhs;
@@ -1083,6 +1635,42 @@ namespace hxm
     inline vec5i operator-(vec5i lhs, const vec5i& rhs)
     {
         lhs -= rhs;
+        return lhs;
+    }
+
+    inline vec5i operator-(vec5i lhs, const int32_t rhs)
+    {
+        lhs -= rhs;
+        return lhs;
+    }
+
+    // negation operator
+    inline vec5i operator-(const vec5i& lhs)
+    {
+        return vec5i(-lhs.x, -lhs.y, -lhs.z, -lhs.w, -lhs.v);
+    }
+
+    inline vec5i operator*(vec5i lhs, const vec5i& rhs)
+    {
+        lhs *= rhs;
+        return lhs;
+    }
+
+    inline vec5i operator*(vec5i lhs, const float rhs)
+    {
+        lhs *= rhs;
+        return lhs;
+    }
+
+    inline vec5i operator/(vec5i lhs, const vec5i& rhs)
+    {
+        lhs /= rhs;
+        return lhs;
+    }
+
+    inline vec5i operator/(vec5i lhs, const float rhs)
+    {
+        lhs /= rhs;
         return lhs;
     }
 
@@ -1096,7 +1684,17 @@ namespace hxm
         return v;
     }
 
-    inline vec5i vecAbs(vec5i v)
+    inline vec5i clamp(vec5i v, const int32_t vMin, const int32_t vMax)
+    {
+        v.x = std::max(std::min(v.x, vMax), vMin);
+        v.y = std::max(std::min(v.y, vMax), vMin);
+        v.z = std::max(std::min(v.z, vMax), vMin);
+        v.w = std::max(std::min(v.w, vMax), vMin);
+        v.v = std::max(std::min(v.v, vMax), vMin);
+        return v;
+    }
+
+    inline vec5i vabs(vec5i v)
     {
         v.x = std::abs(v.x);
         v.y = std::abs(v.y);
@@ -1130,5 +1728,150 @@ namespace hxm
         result.w = (a.w + ((abs(a.w / b.w) + 1) * b.w)) % b.w;
         result.v = (a.v + ((abs(a.v / b.v) + 1) * b.v)) % b.v;
         return result;
+    }
+
+    inline vec5i operator<<(vec5i lhs, const uint32_t rhs)
+    {
+        lhs.x <<= rhs;
+        lhs.y <<= rhs;
+        lhs.z <<= rhs;
+        lhs.w <<= rhs;
+        lhs.v <<= rhs;
+        return lhs;
+    }
+
+    inline vec5i operator>>(vec5i lhs, const uint32_t rhs)
+    {
+        lhs.x >>= rhs;
+        lhs.y >>= rhs;
+        lhs.z >>= rhs;
+        lhs.w >>= rhs;
+        lhs.v >>= rhs;
+        return lhs;
+    }
+
+
+    // VEC5U ------------------------------------------------------------------
+    class vec5u {
+        // Members
+    private:
+    protected:
+    public:
+        union
+        {
+            uint32_t _v[5];
+            struct { uint32_t x, y, z, w, v; };
+        };
+
+        // Functions
+    private:
+    protected:
+    public:
+        vec5u& operator+=(const vec5u& rhs);
+        vec5u& operator+=(const uint32_t rhs);
+        vec5u& operator-=(const vec5u& rhs);
+        vec5u& operator-=(const uint32_t rhs);
+        vec5u& operator*=(const vec5u& rhs);
+        vec5u& operator*=(const uint32_t rhs);
+        vec5u& operator/=(const vec5u& rhs);
+        vec5u& operator/=(const uint32_t rhs);
+        bool operator==(const vec5u& rhs) const;
+        bool operator!=(const vec5u& rhs) const;
+        uint32_t& operator[](uint32_t idx);
+        uint32_t operator[](uint32_t idx) const;
+
+        vec5u();
+        vec5u(uint32_t v);
+        vec5u(uint32_t x, uint32_t y, uint32_t z, uint32_t w, uint32_t v);
+        vec5u(const vec5f& fvec);
+        vec5u(const vec5i& ivec);
+    };
+
+    inline vec5u operator+(vec5u lhs, const vec5u& rhs)
+    {
+        lhs += rhs;
+        return lhs;
+    }
+
+    inline vec5u operator+(vec5u lhs, const uint32_t rhs)
+    {
+        lhs += rhs;
+        return lhs;
+    }
+
+    inline vec5u operator-(vec5u lhs, const vec5u& rhs)
+    {
+        lhs -= rhs;
+        return lhs;
+    }
+
+    inline vec5u operator-(vec5u lhs, const uint32_t rhs)
+    {
+        lhs -= rhs;
+        return lhs;
+    }
+
+    inline vec5u operator*(vec5u lhs, const vec5u& rhs)
+    {
+        lhs *= rhs;
+        return lhs;
+    }
+
+    inline vec5u operator*(vec5u lhs, const uint32_t rhs)
+    {
+        lhs *= rhs;
+        return lhs;
+    }
+
+    inline vec5u operator/(vec5u lhs, const vec5u& rhs)
+    {
+        lhs /= rhs;
+        return lhs;
+    }
+
+    inline vec5u operator/(vec5u lhs, const uint32_t rhs)
+    {
+        lhs /= rhs;
+        return lhs;
+    }
+
+    inline vec5u clamp(vec5u v, const vec5u& vMin, const vec5u& vMax)
+    {
+        v.x = std::max(std::min(v.x, vMax.x), vMin.x);
+        v.y = std::max(std::min(v.y, vMax.y), vMin.y);
+        v.z = std::max(std::min(v.z, vMax.z), vMin.z);
+        v.w = std::max(std::min(v.w, vMax.w), vMin.w);
+        v.v = std::max(std::min(v.v, vMax.v), vMin.v);
+        return v;
+    }
+
+    inline vec5u clamp(vec5u v, const uint32_t vMin, const uint32_t vMax)
+    {
+        v.x = std::max(std::min(v.x, vMax), vMin);
+        v.y = std::max(std::min(v.y, vMax), vMin);
+        v.z = std::max(std::min(v.z, vMax), vMin);
+        v.w = std::max(std::min(v.w, vMax), vMin);
+        v.v = std::max(std::min(v.v, vMax), vMin);
+        return v;
+    }
+
+    inline vec5u operator<<(vec5u lhs, const uint32_t rhs)
+    {
+        lhs.x <<= rhs;
+        lhs.y <<= rhs;
+        lhs.z <<= rhs;
+        lhs.w <<= rhs;
+        lhs.v <<= rhs;
+        return lhs;
+    }
+
+    inline vec5u operator>>(vec5u lhs, const uint32_t rhs)
+    {
+        lhs.x >>= rhs;
+        lhs.y >>= rhs;
+        lhs.z >>= rhs;
+        lhs.w >>= rhs;
+        lhs.v >>= rhs;
+        return lhs;
     }
 }

--- a/src/vecUtils.h
+++ b/src/vecUtils.h
@@ -1,0 +1,195 @@
+/*
+vecUtils.h
+March 2026
+Contributors:
+Justin Jensen
+*/
+
+#pragma once
+
+#include "vec.h"
+
+namespace hxm
+{
+    // TODO: standardize this API as well
+    // the index of the smallest component of this vector
+    inline uint32_t minIdx(const vec2f& v)
+    {
+        uint32_t minIdx = 0;
+        float minVal = FLT_MAX;
+        for (uint32_t idx = 0; idx < 2; idx++)
+        {
+            // don't consider components with -infinity values
+            if (!std::isinf(v[idx]) && v[idx] < minVal)
+            {
+                minIdx = idx;
+                minVal = v[idx];
+            }
+        }
+
+        return minIdx;
+    }
+
+    // the index of the largest component of this vector
+    inline uint32_t maxIdx(const vec2f& v)
+    {
+        uint32_t maxIdx = 0;
+        float maxVal = FLT_MAX;
+        for (uint32_t idx = 0; idx < 2; idx++)
+        {
+            // don't consider components with infinity values
+            if (!std::isinf(v[idx]) && v[idx] > maxVal)
+            {
+                maxIdx = idx;
+                maxVal = v[idx];
+            }
+        }
+
+        return maxIdx;
+    }
+
+
+
+    inline uint32_t minIdx(const vec3f& v)
+    {
+        uint32_t minIdx = 0;
+        float minVal = FLT_MAX;
+        for (uint32_t idx = 0; idx < 3; idx++)
+        {
+            // don't consider components with -infinity values
+            if (!std::isinf(v[idx]) && v[idx] < minVal)
+            {
+                minIdx = idx;
+                minVal = v[idx];
+            }
+        }
+
+        return minIdx;
+    }
+
+    inline uint32_t maxIdx(const vec3f& v)
+    {
+        uint32_t maxIdx = 0;
+        float maxVal = FLT_MAX;
+        for (uint32_t idx = 0; idx < 3; idx++)
+        {
+            // don't consider components with infinity values
+            if (!std::isinf(v[idx]) && v[idx] > maxVal)
+            {
+                maxIdx = idx;
+                maxVal = v[idx];
+            }
+        }
+
+        return maxIdx;
+    }
+
+
+    inline int32_t firstNonZeroComp(const vec4i& v)
+    {
+        for (int idx = 0; idx < 4; idx++)
+        {
+            if (v[idx] != 0)
+            {
+                return idx;
+            }
+        }
+
+        return -1;
+    }
+
+
+    inline uint32_t numEqualComps(const vec4u& a, const vec4u& b)
+    {
+        size_t result = 0;
+        result += a.x == b.x ? 1 : 0;
+        result += a.y == b.y ? 1 : 0;
+        result += a.z == b.z ? 1 : 0;
+        result += a.w == b.w ? 1 : 0;
+        return result;
+    }
+
+
+    inline uint32_t minIdx(const vec4f& v)
+    {
+        uint32_t minIdx = 0;
+        float minVal = FLT_MAX;
+        for (uint32_t idx = 0; idx < 4; idx++)
+        {
+            // don't consider components with -infinity values
+            if (!std::isinf(v[idx]) && v[idx] < minVal)
+            {
+                minIdx = idx;
+                minVal = v[idx];
+            }
+        }
+
+        return minIdx;
+    }
+
+    inline uint32_t maxIdx(const vec4f& v)
+    {
+        uint32_t maxIdx = 0;
+        float maxVal = FLT_MAX;
+        for (uint32_t idx = 0; idx < 4; idx++)
+        {
+            // don't consider components with infinity values
+            if (!std::isinf(v[idx]) && v[idx] > maxVal)
+            {
+                maxIdx = idx;
+                maxVal = v[idx];
+            }
+        }
+
+        return maxIdx;
+    }
+
+
+    inline uint32_t minIdx(const vec5f& v)
+    {
+        uint32_t minIdx = 0;
+        float minVal = FLT_MAX;
+        for (uint32_t idx = 0; idx < 5; idx++)
+        {
+            // don't consider components with -infinity values
+            if (!std::isinf(v[idx]) && v[idx] < minVal)
+            {
+                minIdx = idx;
+                minVal = v[idx];
+            }
+        }
+
+        return minIdx;
+    }
+
+    inline uint32_t maxIdx(const vec5f& v)
+    {
+        uint32_t maxIdx = 0;
+        float maxVal = FLT_MAX;
+        for (uint32_t idx = 0; idx < 5; idx++)
+        {
+            // don't consider components with infinity values
+            if (!std::isinf(v[idx]) && v[idx] > maxVal)
+            {
+                maxIdx = idx;
+                maxVal = v[idx];
+            }
+        }
+
+        return maxIdx;
+    }
+
+
+    inline int32_t firstNonZeroComp(const vec5i& v)
+    {
+        for (int idx = 0; idx < 5; idx++)
+        {
+            if (v[idx] != 0)
+            {
+                return idx;
+            }
+        }
+
+        return -1;
+    }
+}


### PR DESCRIPTION
## First pass at standardizing the vector APIs
Vectors now share the same set of operations and inline functions.
There are a few notable exceptions:

- unsigned vector types don't have a `vabs()` function
- integer vector types don't have a `round()` function
- integer vector types have bit shift operators
- floating-point vector types don't have a `mod()` function

### Also

- Added `vec5u` class
- Added `aabb3i` class
- vector `.normalize()` function returns the length of the vector before normalization
- moved some vector helper functions to a separate `vecUtils.h` file